### PR TITLE
Extend aggregate_ping renderer

### DIFF
--- a/ripe/atlas/tools/renderers/aggregate_ping.py
+++ b/ripe/atlas/tools/renderers/aggregate_ping.py
@@ -11,22 +11,58 @@ class Renderer(BaseRenderer):
     RENDERS = [BaseRenderer.TYPE_PING]
 
     def __init__(self):
+        self.target = ""
+        self.packet_loss = 0
         self.totals = {
             "sent": 0,
-            "received": 0
+            "received": 0,
+            "min": [],
+            "rtts": [],
+            "max": []
         }
+
+    @staticmethod
+    def mean(rtts):
+        return round(float(sum(rtt for rtt in rtts if rtt is not None))/max(len(rtts),1), 3)
+
+    @staticmethod
+    def median(rtts):
+        sorted_rtts = sorted(rtts)
+        index = (len(rtts) - 1) // 2
+        if (len(rtts) % 2):
+            return sorted_rtts[index]
+        else:
+            return (sorted_rtts[index] + sorted_rtts[index +1])/2.0
 
     def on_start(self):
         return "Collecting results...\n"
 
     def on_result(self, result, probes=None):
-
+        # destination_name is included in every ping result
+        # but not exposed to on_start, on_finish via msm metadata
+        # set it only if it was empty
+        if self.target == "":
+            self.target = result.destination_name
         self.totals["sent"] += result.packets_sent
         self.totals["received"] += result.packets_received
+        self.totals["min"].append(result.rtt_min)
+        self.totals["max"].append(result.rtt_max)
+
+        for packet in result.packets:
+            self.totals["rtts"].append(packet.rtt)
 
         return ""
 
     def on_finish(self):
-        return "\nTotals:\n  Sent: {sent}\n  Received: {received}\n".format(
-            **self.totals
+        self.packet_loss = (1 - float(self.totals["received"]) / self.totals["sent"]) * 100
+        return self.render(
+            "reports/aggregate_ping.txt",
+            target=self.target,
+            sent=self.totals["sent"],
+            received=self.totals["received"],
+            packet_loss=self.packet_loss,
+            min=min(min for min in self.totals["min"] if min is not None),
+            median=self.median(self.totals["rtts"]),
+            mean=self.mean(self.totals["rtts"]),
+            max=max(self.totals["max"])
         )

--- a/ripe/atlas/tools/renderers/templates/reports/aggregate_ping.txt
+++ b/ripe/atlas/tools/renderers/templates/reports/aggregate_ping.txt
@@ -1,0 +1,3 @@
+-- {target} ping statistics ---
+{sent} packets transmitted, {received} received, {packet_loss}% loss
+rtt min/med/avg/max = {min}/{median}/{mean}/{max} ms


### PR DESCRIPTION
It still needs more love (better formatting, testing...), but at least it works with msm#1001:
```
$ ripe-atlas report --renderer aggregate_ping 1001

RIPE Atlas Report for Measurement #1001
===================================================
Collecting results...
-- 193.0.14.129 ping statistics ---
26711 packets transmitted, 26350 received, 1.35150312605% loss
rtt min/med/avg/max = 0.209/33.274/60.5296812673/14027.879 ms
```
We'll rebase all the commits in this PR before merging.

Also, how about adding this to the standard ping renderer?