### PR TITLE
Replaced pipes with spaces

### DIFF
--- a/ripe/atlas/tools/commands/probes.py
+++ b/ripe/atlas/tools/commands/probes.py
@@ -19,8 +19,12 @@ class Command(BaseCommand):
         "given filters."
     )
 
+    def __init__(self, *args, **kwargs):
+        BaseCommand.__init__(self, *args, **kwargs)
+        self.renderer = None
+
     def add_arguments(self):
-        """Adds all commands line argumentes for this command."""
+        """Adds all commands line arguments for this command."""
         asn = self.parser.add_argument_group("ASN")
         asn.add_argument(
             "--asn",
@@ -119,7 +123,7 @@ class Command(BaseCommand):
             "--ids-only",
             action='store_true',
             help=(
-                "Print only IDs of probes. Usefull to pipe it to another "
+                "Print only IDs of probes. Useful to pipe it to another "
                 "command."
             )
         )
@@ -142,17 +146,16 @@ class Command(BaseCommand):
         self.renderer.on_start()
 
         if self.arguments.aggregate_by:
-
             aggregators = self.get_aggregators()
             buckets = aggregate(probes, aggregators)
             self.renderer.render_aggregation(buckets)
         else:
-
             self.renderer.on_table_title()
             for index, probe in enumerate(probes):
                 self.renderer.on_result(probe)
 
-        self.renderer.on_finish(probes_request.total_count)
+        self.renderer.total_count = probes_request.total_count
+        self.renderer.on_finish()
 
     def produce_ids_only(self, probes):
         """If user has specified ids-only arg print only ids and exit."""
@@ -201,9 +204,7 @@ class Command(BaseCommand):
         set_args = [k for k, v in vars(self.arguments).items() if v]
         if not set_args:
             raise RipeAtlasToolsException(
-                "You should specify at least one argument. Try -h option for "
-                "usuage."
-            )
+                "You must specify at least one argument. Try --help for usage.")
 
         if any(
             [self.arguments.asn, self.arguments.asnv4, self.arguments.asnv6]

--- a/ripe/atlas/tools/commands/probes.py
+++ b/ripe/atlas/tools/commands/probes.py
@@ -146,10 +146,13 @@ class Command(BaseCommand):
         self.renderer.on_start()
 
         if self.arguments.aggregate_by:
+
             aggregators = self.get_aggregators()
             buckets = aggregate(probes, aggregators)
             self.renderer.render_aggregation(buckets)
+
         else:
+
             self.renderer.on_table_title()
             for index, probe in enumerate(probes):
                 self.renderer.on_result(probe)

--- a/ripe/atlas/tools/probes/__init__.py
+++ b/ripe/atlas/tools/probes/__init__.py
@@ -11,10 +11,6 @@ class Probe(object):
 
     EXPIRE_TIME = 60 * 60 * 24 * 30
 
-    def __init__(self, id, meta_data=None):
-
-        return CProbe(id, meta_data)
-
     @classmethod
     def get(cls, pk):
         """

--- a/ripe/atlas/tools/renderers/probes.py
+++ b/ripe/atlas/tools/renderers/probes.py
@@ -33,7 +33,7 @@ class Renderer(BaseRenderer):
 
         if not self.custom_format_flag:
             header_fields = ["ID", "ASNv4", "ASNv6", "CC", "Status"]
-            header_template = "{:<5} {:<6} {:<6} {:<2} {:<10}"
+            header_template = "{:<5} {:<6} {:<6} {:<2} {:<12}"
         else:
             for field in self.fields:
                 header_fields.append(field.upper())
@@ -54,7 +54,7 @@ class Renderer(BaseRenderer):
 
         if not self.custom_format_flag:
             self.fields = ["id", "asn_v4", "asn_v6", "country_code", "status"]
-            self.probe_template = "{:<5} {:<6} {:<6} {:^2} {:<}"
+            self.probe_template = "{:<5} {:<6} {:<6} {:^2} {:<12}"
         else:
             for field in self.fields:
                 self.probe_template += " {:<}"

--- a/ripe/atlas/tools/renderers/probes.py
+++ b/ripe/atlas/tools/renderers/probes.py
@@ -6,14 +6,16 @@ class Renderer(BaseRenderer):
 
     RENDERS = []
 
-    def __init__(self, fields=[], additional_fields=[], max_per_aggr=None):
+    def __init__(self, fields=None, additional_fields=None, max_per_aggr=None):
+
         self.blob = ""
-        self.additional_fields = additional_fields
+        self.additional_fields = additional_fields or []
         self.probe_template = ""
         self.header_message = ""
         self.fields = []
         self.max_per_aggr = max_per_aggr
         self.custom_format_flag = False
+        self.total_count = 0
 
         if fields:
             self.custom_format_flag = True
@@ -31,14 +33,14 @@ class Renderer(BaseRenderer):
 
         if not self.custom_format_flag:
             header_fields = ["ID", "ASNv4", "ASNv6", "CC", "Status"]
-            header_template = "{:<5}|{:<6}|{:<6}|{:<2}|{:<10}|"
+            header_template = "{:<5} {:<6} {:<6} {:<2} {:<10}"
         else:
             for field in self.fields:
                 header_fields.append(field.upper())
-                header_template += "{:<}|"
+                header_template += " {:<}"
 
         for field in self.additional_fields:
-            header_template += "{:<}|"
+            header_template += " {:<}"
             header_fields.append(field)
 
         self.header_message = header_template.format(*header_fields)
@@ -52,13 +54,13 @@ class Renderer(BaseRenderer):
 
         if not self.custom_format_flag:
             self.fields = ["id", "asn_v4", "asn_v6", "country_code", "status"]
-            self.probe_template = "{:<5}|{:<6}|{:<6}|{:^2}|{:<}|"
+            self.probe_template = "{:<5} {:<6} {:<6} {:^2} {:<}"
         else:
             for field in self.fields:
-                self.probe_template += "{:<}|"
+                self.probe_template += " {:<}"
 
         for fields in self.additional_fields:
-            self.probe_template += "{:<}|"
+            self.probe_template += " {:<}"
 
     def render_aggregation(self, aggregation_data, indent=""):
         """
@@ -85,21 +87,21 @@ class Renderer(BaseRenderer):
 
     def on_table_title(self, indent=""):
         """Renders the header of the table"""
-        self.blob += "{0}{1}\n".format(indent, self.header_message)
+        self.blob += "{}{}\n".format(indent, self.header_message)
 
     def on_aggregation_title(self, bucket, indent=""):
         """Renders the title of each aggregation bucket."""
-        self.blob += "{0}\n".format(indent + bucket)
+        self.blob += "{}\n".format(indent + bucket)
 
     def on_result(self, result, probes=None, indent=""):
         fields = []
 
         for field in self.fields:
-            fields.append(getattr(result, field, "Undefined"))
+            fields.append(getattr(result, field, ""))
 
         message = self.probe_template.format(*fields)
-        self.blob += "{0}{1}\n".format(indent, message)
+        self.blob += "{}{}\n".format(indent, message)
 
-    def on_finish(self, total_count):
-        self.blob += "Total probes found: {0}\n".format(total_count)
+    def on_finish(self):
+        self.blob += "Total probes found: {}\n".format(self.total_count)
         sys.stdout.write(self.blob)


### PR DESCRIPTION
Looking for code review on this one.  Much of what I've changed is just PyCharm's linter complaining, and a few typos, but specifically, there's one spot where I've changed the use of pipes to spaces in the probe output to be more like other common unix command line tools (`df`, `ls`, etc.)
