### PR TITLE
Feature/measurements

### DIFF
--- a/ripe/atlas/tools/commands/measurements.py
+++ b/ripe/atlas/tools/commands/measurements.py
@@ -12,7 +12,6 @@ from ..helpers.validators import ArgumentType
 class Command(BaseCommand):
 
     NAME = "measurements"
-    MAX_RESULTS = 50
 
     DESCRIPTION = (
         "Fetches and prints measurements fulfilling specified criteria based "
@@ -54,6 +53,12 @@ class Command(BaseCommand):
             type=ArgumentType.datetime,
             help=""
         )
+        self.parser.add_argument(
+            "--limit",
+            type=ArgumentType.integer_range(1, 1000),
+            default=50,
+            help="The number of measurements to return."
+        )
 
     def run(self):
 
@@ -70,7 +75,7 @@ class Command(BaseCommand):
         print("\n{:<8} {:10} {:<45} {:>14}\n{}".format(
             "ID", "Type", "Description", "Status", "=" * 80
         ))
-        for measurement in itertools.islice(measurements, self.MAX_RESULTS):
+        for measurement in itertools.islice(measurements, self.arguments.limit):
 
             destination = measurement.destination_name or \
                 measurement.destination_address or \
@@ -87,7 +92,7 @@ class Command(BaseCommand):
         print("{}\n{:>80}".format(
             "=" * 80,
             "Showing {} of {} total measurements".format(
-                min(self.MAX_RESULTS, measurements.total_count),
+                min(self.arguments.limit, measurements.total_count),
                 measurements.total_count
             )
         ))

--- a/ripe/atlas/tools/commands/measurements.py
+++ b/ripe/atlas/tools/commands/measurements.py
@@ -46,30 +46,15 @@ class Command(BaseCommand):
         )
 
         timing = self.parser.add_argument_group("Timing")
-        timing.add_argument(
-            "--started-before",
-            type=ArgumentType.datetime,
-            help="Filter for measurements that started before a specific date. "
-                 "The format required is YYYY-MM-DDTHH:MM:SS"
-        )
-        timing.add_argument(
-            "--started-after",
-            type=ArgumentType.datetime,
-            help="Filter for measurements that started after a specific date. "
-                 "The format required is YYYY-MM-DDTHH:MM:SS"
-        )
-        timing.add_argument(
-            "--stopped-before",
-            type=ArgumentType.datetime,
-            help="Filter for measurements that stopped before a specific date. "
-                 "The format required is YYYY-MM-DDTHH:MM:SS"
-        )
-        timing.add_argument(
-            "--stopped-after",
-            type=ArgumentType.datetime,
-            help="Filter for measurements that stopped after a specific date. "
-                 "The format required is YYYY-MM-DDTHH:MM:SS"
-        )
+        for position in ("started", "stopped"):
+            for chrono in ("before", "after"):
+                timing.add_argument(
+                    "--{}-{}".format(position, chrono),
+                    type=ArgumentType.datetime,
+                    help="Filter for measurements that {} {} a specific date. "
+                         "The format required is YYYY-MM-DDTHH:MM:SS".format(
+                             position, chrono)
+                )
 
         self.parser.add_argument(
             "--limit",
@@ -112,6 +97,8 @@ class Command(BaseCommand):
 
         r = {"return_objects": True}
 
+        if self.arguments.search:
+            r["search"] = self.arguments.search
         if self.arguments.status:
             r["status"] = self.arguments.status
         if self.arguments.af:

--- a/ripe/atlas/tools/commands/measurements.py
+++ b/ripe/atlas/tools/commands/measurements.py
@@ -1,0 +1,63 @@
+from __future__ import print_function, absolute_import
+import sys
+import requests
+
+from ripe.atlas.cousteau import MeasurementRequest
+from ripe.atlas.tools.aggregators import ValueKeyAggregator, aggregate
+
+from ..exceptions import RipeAtlasToolsException
+from ..renderers.probes import Renderer
+from .base import Command as BaseCommand
+
+
+class Command(BaseCommand):
+
+    NAME = "probes"
+
+    DESCRIPTION = (
+        "Fetches and prints measurements fulfilling specified criteria based "
+        "on given filters."
+    )
+
+    def add_arguments(self):
+        """Adds all commands line arguments for this command."""
+        self.parser.add_argument(
+            "--search",
+            type=str,
+            help="A search string.  This could match the target or description"
+        )
+        self.parser.add_argument(
+            "--status",
+            type=str,
+            choices=("scheduled", "ongoing", "stopped"),
+            help="The measurement status"
+        )
+        self.parser.add_argument(
+            "--af",
+            type=int,
+            choices=(4, 6),
+            help="The address family"
+        )
+        self.parser.add_argument(
+            "--type",
+            type=str,
+            choices=("ping", "traceroute", "dns", "ssl", "ntp", "http"),
+            help="The measurement type"
+        )
+
+    def run(self):
+
+        filters = {"return_objects": True}
+        if self.arguments.status:
+            filters["status"] = 1
+        if self.arguments.af:
+            filters["af"] = self.arguments.af
+        if self.arguments.type:
+            filters["type"] = self.arguments.type
+        measurements = MeasurementRequest(**filters)
+
+        for measurement in measurements:
+            print(measurement.id)
+
+        # Print total count of found measurements
+        print(measurements.total_count)

--- a/ripe/atlas/tools/commands/probes.py
+++ b/ripe/atlas/tools/commands/probes.py
@@ -81,7 +81,7 @@ class Command(BaseCommand):
         self.parser.add_argument(
             "--limit",
             type=int,
-            help="Return limited amount of probes"
+            help="Return limited number of probes"
         )
         self.parser.add_argument(
             "--additional-fields",

--- a/ripe/atlas/tools/commands/probes.py
+++ b/ripe/atlas/tools/commands/probes.py
@@ -19,10 +19,6 @@ class Command(BaseCommand):
         "given filters."
     )
 
-    def __init__(self, *args, **kwargs):
-        BaseCommand.__init__(self, *args, **kwargs)
-        self.renderer = None
-
     def add_arguments(self):
         """Adds all commands line arguments for this command."""
         asn = self.parser.add_argument_group("ASN")
@@ -142,23 +138,23 @@ class Command(BaseCommand):
             return
 
         render_args = self._clean_render_args()
-        self.renderer = Renderer(**render_args)
-        self.renderer.on_start()
+        renderer = Renderer(**render_args)
+        renderer.on_start()
 
         if self.arguments.aggregate_by:
 
             aggregators = self.get_aggregators()
             buckets = aggregate(probes, aggregators)
-            self.renderer.render_aggregation(buckets)
+            renderer.render_aggregation(buckets)
 
         else:
 
-            self.renderer.on_table_title()
+            renderer.on_table_title()
             for index, probe in enumerate(probes):
-                self.renderer.on_result(probe)
+                renderer.on_result(probe)
 
-        self.renderer.total_count = probes_request.total_count
-        self.renderer.on_finish()
+        renderer.total_count = probes_request.total_count
+        renderer.on_finish()
 
     def produce_ids_only(self, probes):
         """If user has specified ids-only arg print only ids and exit."""

--- a/ripe/atlas/tools/helpers/colours.py
+++ b/ripe/atlas/tools/helpers/colours.py
@@ -4,44 +4,44 @@ import sys
 class Colour(object):
 
     @classmethod
-    def _colourise(cls, t, c):
-        return "{}[{}m{}{}[0m".format(chr(0x1b), c, t, chr(0x1b))
+    def _colourise(cls, text, colour):
+        return "{}[{}m{}{}[0m".format(chr(0x1b), colour, text, chr(0x1b))
 
     @classmethod
-    def black(cls, t):
-        return cls._colourise(t, 30)
+    def black(cls, text):
+        return cls._colourise(text, 30)
 
     @classmethod
-    def red(cls, t):
-        return cls._colourise(t, 31)
+    def red(cls, text):
+        return cls._colourise(text, 31)
 
     @classmethod
-    def green(cls, t):
-        return cls._colourise(t, 32)
+    def green(cls, text):
+        return cls._colourise(text, 32)
 
     @classmethod
-    def yellow(cls, t):
-        return cls._colourise(t, 33)
+    def yellow(cls, text):
+        return cls._colourise(text, 33)
 
     @classmethod
-    def blue(cls, t):
-        return cls._colourise(t, 34)
+    def blue(cls, text):
+        return cls._colourise(text, 34)
 
     @classmethod
-    def mangenta(cls, t):
-        return cls._colourise(t, 35)
+    def mangenta(cls, text):
+        return cls._colourise(text, 35)
 
     @classmethod
-    def cyan(cls, t):
-        return cls._colourise(t, 36)
+    def cyan(cls, text):
+        return cls._colourise(text, 36)
 
     @classmethod
-    def white(cls,t):
-        return cls._colourise(t, 37)
+    def white(cls, text):
+        return cls._colourise(text, 37)
 
     @classmethod
-    def bold(cls, t):
-        return cls._colourise(t, 1)
+    def bold(cls, text):
+        return cls._colourise(text, 1)
 
 
 def colourise(text, colour):

--- a/ripe/atlas/tools/helpers/validators.py
+++ b/ripe/atlas/tools/helpers/validators.py
@@ -46,3 +46,26 @@ class ArgumentType(object):
                 "2010-10-01T00:00:00 or a portion thereof.  All times are in "
                 "UTC."
             )
+
+    class integer_range(object):
+
+        def __init__(self, minimum=0, maximum=7):
+            self.minimum = minimum
+            self.maximum = maximum
+
+        def __call__(self, string, *args, **kwargs):
+            try:
+                integer = int(string)
+                if integer < self.minimum or integer > self.maximum:
+                    raise argparse.ArgumentTypeError(
+                        "The integer must be between {} and {}.".format(
+                            self.minimum,
+                            self.maximum
+                        )
+                    )
+            except ValueError:
+                raise argparse.ArgumentTypeError(
+                    "An integer must be specified."
+                )
+
+            return integer

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,5 +1,6 @@
-from aggregators import TestAggregators
-from commands import TestProbesCommand
-from renderers import TestPingRenderer
+from .aggregators import TestAggregators
+from .commands import TestProbesCommand
+from .helpers import TestArgumentTypeHelper
+from .renderers import TestPingRenderer
 
 __all__ = [TestAggregators, TestProbesCommand, TestPingRenderer]

--- a/tests/commands/__init__.py
+++ b/tests/commands/__init__.py
@@ -1,3 +1,4 @@
-from probes import TestProbesCommand
+from .probes import TestProbesCommand
+from .report import TestReportCommand
 
-__all__ = [probes]
+__all__ = [TestProbesCommand, TestReportCommand]

--- a/tests/commands/measurements.py
+++ b/tests/commands/measurements.py
@@ -1,7 +1,57 @@
 import sys
-import mock
+
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
 import unittest
+from collections import namedtuple
+
+from ripe.atlas.tools.commands.measurements import Command
+
+
+class FakeGen(object):
+    """
+    A rip-off of the code used for testing probes, but a little prettier.
+    """
+
+    Measurement = namedtuple(
+        "Measurement",
+        ("id", "type", "status", "status_id", "meta_data", "destination_name")
+    )
+
+    def __init__(self):
+        self.data = [
+            self.Measurement(id=1, type="ping", status="Ongoing", status_id=2, meta_data={"status": {"name": "Ongoing", "id": 2}}, destination_name="Name 1",),
+            self.Measurement(id=2, type="ping", status="Ongoing", status_id=2, meta_data={"status": {"name": "Ongoing", "id": 2}}, destination_name="Name 2",),
+            self.Measurement(id=3, type="ping", status="Ongoing", status_id=2, meta_data={"status": {"name": "Ongoing", "id": 2}}, destination_name="Name 3",),
+            self.Measurement(id=4, type="ping", status="Ongoing", status_id=2, meta_data={"status": {"name": "Ongoing", "id": 2}}, destination_name="Name 4",),
+            self.Measurement(id=5, type="ping", status="Ongoing", status_id=2, meta_data={"status": {"name": "Ongoing", "id": 2}}, destination_name="Name 5",),
+        ]
+        self.total_count = 5
+
+    def __iter__(self):
+        return self
+
+    # Python 3 compatibility
+    def __next__(self):
+        return self.next()
+
+    def next(self):
+        if not self.data:
+            raise StopIteration()
+        else:
+            return self.data.pop(0)
 
 
 class TestMeasurementsCommand(unittest.TestCase):
-    pass
+
+    def setUp(self):
+        self.cmd = Command()
+
+    @mock.patch("ripe.atlas.tools.commands.measurements.MeasurementRequest")
+    def test_with_empty_args(self, mock_request):
+        mock_request.return_value = FakeGen()
+        self.cmd.init_args([])
+        self.cmd.run()

--- a/tests/commands/measurements.py
+++ b/tests/commands/measurements.py
@@ -1,0 +1,7 @@
+import sys
+import mock
+import unittest
+
+
+class TestMeasurementsCommand(unittest.TestCase):
+    pass

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,3 @@
+from .validators import TestArgumentTypeHelper
+
+__all__ = [TestArgumentTypeHelper]

--- a/tests/helpers/validators.py
+++ b/tests/helpers/validators.py
@@ -1,0 +1,69 @@
+import argparse
+import datetime
+import unittest
+
+from ripe.atlas.tools.helpers.validators import ArgumentType
+
+
+class TestArgumentTypeHelper(unittest.TestCase):
+
+    def test_path(self):
+
+        self.assertEqual("/tmp", ArgumentType.path("/tmp"))
+
+        with self.assertRaises(argparse.ArgumentTypeError):
+            ArgumentType.path("/not/a/real/place")
+
+    def test_country_code(self):
+
+        self.assertEqual("CA", ArgumentType.country_code("CA"))
+        self.assertEqual("CA", ArgumentType.country_code("ca"))
+        self.assertEqual("CA", ArgumentType.country_code("Ca"))
+        self.assertEqual("CA", ArgumentType.country_code("cA"))
+
+        for value in ("CAN", "Canada", "can", "This isn't even a country"):
+            with self.assertRaises(argparse.ArgumentTypeError):
+                ArgumentType.country_code(value)
+
+    def test_comma_separated_integers(self):
+
+        self.assertEqual(
+            [1, 2, 3], ArgumentType.comma_separated_integers("1,2,3"))
+
+        self.assertEqual(
+            [1, 2, 3], ArgumentType.comma_separated_integers("1, 2, 3"))
+
+        self.assertEqual([1], ArgumentType.comma_separated_integers("1"))
+
+        with self.assertRaises(argparse.ArgumentTypeError):
+            ArgumentType.comma_separated_integers("1,2,3,pizza!")
+
+    def test_datetime(self):
+
+        d = datetime.datetime(2015, 12, 1)
+
+        self.assertEqual(d, ArgumentType.datetime("2015-12-1"))
+        self.assertEqual(d, ArgumentType.datetime("2015-12-1T00"))
+        self.assertEqual(d, ArgumentType.datetime("2015-12-1T00:00"))
+        self.assertEqual(d, ArgumentType.datetime("2015-12-1T00:00:00"))
+        self.assertEqual(d, ArgumentType.datetime("2015-12-1"))
+        self.assertEqual(d, ArgumentType.datetime("2015-12-1 00"))
+        self.assertEqual(d, ArgumentType.datetime("2015-12-1 00:00"))
+        self.assertEqual(d, ArgumentType.datetime("2015-12-1 00:00:00"))
+
+        with self.assertRaises(argparse.ArgumentTypeError):
+            ArgumentType.datetime("yesterday")
+
+        with self.assertRaises(argparse.ArgumentTypeError):
+            ArgumentType.datetime("Definitely not a date, or even a time")
+
+    def test_integer_range(self):
+
+        self.assertEqual(1, ArgumentType.integer_range(1, 10)("1"))
+        self.assertEqual(10, ArgumentType.integer_range(1, 10)("10"))
+        self.assertEqual(1, ArgumentType.integer_range(-1, 1)("1"))
+        self.assertEqual(-1, ArgumentType.integer_range(-1, 1)("-1"))
+
+        for value in ("0", "11", "-1"):
+            with self.assertRaises(argparse.ArgumentTypeError):
+                ArgumentType.integer_range(1, 10)(value)

--- a/tests/renderers/__init__.py
+++ b/tests/renderers/__init__.py
@@ -1,3 +1,3 @@
-from ping import TestPingRenderer
+from .ping import TestPingRenderer
 
 __all__ = [TestPingRenderer]


### PR DESCRIPTION
Much of this is already in #38 `feature/report-times`, so once that's merged, this will look far less daunting.

This code introduces a simple (and colourised!) measurements interface:

```bash
$ ripe-atlas measurements --search <string> --af <4|6> --status <scheduled|ongoing|stopped>
--type <ping|traceroute|dns|sslcert|ntp|http> --started-before YYYY-MM-DDTHH:MM:SS 
--started-after  YYYY-MM-DDTHH:MM:SS --stopped-before  YYYY-MM-DDTHH:MM:SS
--stopped-after YYYY-MM-DDTHH:MM:SS --limit <1:1000>
```

It also introduces a new `ArgumentType` that allows you to specify an integer range value:

```python
self.parser.add_argument(
    "--limit",
    type=ArgumentType.integer_range(1, 1000),
    default=50,
    help="The number of measurements to return.  The number must be "
         "between {} and {}".format(1, 1000)
)
```

It uses the `__call__()` method to allow you to pass arguments to the validator.