### PR TITLE
Added dynamic fields

### DIFF
--- a/ripe/atlas/tools/commands/measurements.py
+++ b/ripe/atlas/tools/commands/measurements.py
@@ -180,7 +180,8 @@ class Command(BaseCommand):
                     "-"
                 )[:self.COLUMNS["target"][1]])
             elif field == "description":
-                r.append(measurement.description[:self.COLUMNS["description"][1]])
+                description = measurement.description or ""
+                r.append(description[:self.COLUMNS["description"][1]])
             else:
                 r.append(getattr(measurement, field))
 


### PR DESCRIPTION
Rather than go with the `--additional-fields` trick we're using in `probes`, I opted for a set default, or a user-based override.  So if you do this:

    ripe-atlas measurements --search ripe.net

You get the standard set of fields (id, type, description, status).  However if you specify multiple `--field` arguments, you can pick and choose:

    ripe-atlas measurements --field id --field type --field url --field target --field description --type dns --field status --started-after 2015
