### PR TITLE
Test coverage for the <measure> command

### DIFF
--- a/ripe/atlas/tools/settings/__init__.py
+++ b/ripe/atlas/tools/settings/__init__.py
@@ -43,10 +43,10 @@ class Configuration(object):
                     "packets": 3,
                     "size": 48,
                     "protocol": "ICMP",
-                    "dontfrag": False,
+                    "dont-fragment": False,
                     "paris": 0,
-                    "firsthop": 1,
-                    "maxhops": 255,
+                    "first-hop": 1,
+                    "max-hops": 255,
                     "port": 80,
                     "destination-option-size": None,
                     "hop-by-hop-option-size": None,
@@ -60,16 +60,15 @@ class Configuration(object):
                     "timeout": 4000
                 },
                 "dns": {
-                    "cd": False,
-                    "do": False,
+                    "set-cd-bit": False,
+                    "set-do-bit": False,
                     "protocol": "UDP",
                     "query-class": "IN",
                     "query-type": "A",
                     "query-argument": None,
-                    "use-nsid": False,
-                    "use-probe-resolver": False,
+                    "set-nsid-bit": False,
                     "udp-payload-size": 512,
-                    "recursion-desired": True,
+                    "set-rd-bit": True,
                     "retry": 0
                 }
             },
@@ -87,7 +86,7 @@ class Configuration(object):
                         "include": [],
                         "exclude": []
                     },
-                    "sslcert": {
+                    "ssl": {
                         "include": [],
                         "exclude": []
                     },
@@ -117,7 +116,7 @@ class Configuration(object):
                         "include": [],
                         "exclude": []
                     },
-                    "sslcert": {
+                    "ssl": {
                         "include": [],
                         "exclude": []
                     },
@@ -183,7 +182,7 @@ class Configuration(object):
         ripe = re.compile("^ripe-ncc:$", re.MULTILINE)
 
         with open(template) as t:
-            payload = t.read().format(
+            payload = str(t.read()).format(
                 payload=yaml.dump(
                     config,
                     default_flow_style=False

--- a/scripts/ripe-atlas
+++ b/scripts/ripe-atlas
@@ -87,3 +87,4 @@ if __name__ == '__main__':
         sys.exit(RipeAtlas().main())
     except RipeAtlasToolsException as e:
         e.write()
+        raise SystemExit()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,33 +1,7 @@
-import sys
-
-from contextlib import contextmanager
-from StringIO import StringIO
-
 from .aggregators import TestAggregators
 from .commands import TestProbesCommand
 from .helpers import TestArgumentTypeHelper
 from .renderers import TestPingRenderer
-
-
-@contextmanager
-def capture_sys_output():
-    """
-    Wrap a block with this, and it'll capture standard out and standard error
-    into handy variables:
-
-      with capture_sys_output() as (stdout, stderr):
-          self.cmd.run()
-
-    More info: https://stackoverflow.com/questions/18651705/
-    """
-
-    capture_out, capture_err = StringIO(), StringIO()
-    current_out, current_err = sys.stdout, sys.stderr
-    try:
-        sys.stdout, sys.stderr = capture_out, capture_err
-        yield capture_out, capture_err
-    finally:
-        sys.stdout, sys.stderr = current_out, current_err
 
 
 __all__ = [TestAggregators, TestProbesCommand, TestPingRenderer]

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,33 @@
+import sys
+
+from contextlib import contextmanager
+from StringIO import StringIO
+
 from .aggregators import TestAggregators
 from .commands import TestProbesCommand
 from .helpers import TestArgumentTypeHelper
 from .renderers import TestPingRenderer
+
+
+@contextmanager
+def capture_sys_output():
+    """
+    Wrap a block with this, and it'll capture standard out and standard error
+    into handy variables:
+
+      with capture_sys_output() as (stdout, stderr):
+          self.cmd.run()
+
+    More info: https://stackoverflow.com/questions/18651705/
+    """
+
+    capture_out, capture_err = StringIO(), StringIO()
+    current_out, current_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = capture_out, capture_err
+        yield capture_out, capture_err
+    finally:
+        sys.stdout, sys.stderr = current_out, current_err
+
 
 __all__ = [TestAggregators, TestProbesCommand, TestPingRenderer]

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,0 +1,24 @@
+import sys
+
+from contextlib import contextmanager
+from StringIO import StringIO
+
+@contextmanager
+def capture_sys_output():
+    """
+    Wrap a block with this, and it'll capture standard out and standard error
+    into handy variables:
+
+      with capture_sys_output() as (stdout, stderr):
+          self.cmd.run()
+
+    More info: https://stackoverflow.com/questions/18651705/
+    """
+
+    capture_out, capture_err = StringIO(), StringIO()
+    current_out, current_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = capture_out, capture_err
+        yield capture_out, capture_err
+    finally:
+        sys.stdout, sys.stderr = current_out, current_err

--- a/tests/base.py
+++ b/tests/base.py
@@ -1,7 +1,10 @@
 import sys
 
 from contextlib import contextmanager
-from StringIO import StringIO
+try:
+    from cStringIO import StringIO
+except ImportError:  # Python 3
+    from io import StringIO
 
 @contextmanager
 def capture_sys_output():

--- a/tests/commands/__init__.py
+++ b/tests/commands/__init__.py
@@ -1,4 +1,11 @@
+from .measure import TestMeasureCommand
+from .measurements import TestMeasurementsCommand
 from .probes import TestProbesCommand
 from .report import TestReportCommand
 
-__all__ = [TestProbesCommand, TestReportCommand]
+__all__ = [
+    TestMeasureCommand,
+    TestMeasurementsCommand,
+    TestProbesCommand,
+    TestReportCommand
+]

--- a/tests/commands/measure.py
+++ b/tests/commands/measure.py
@@ -1,4 +1,7 @@
+import copy
 import unittest
+
+from random import randint
 
 # Python 3 comes with mock in unittest
 try:
@@ -8,11 +11,15 @@ except ImportError:
 
 from ripe.atlas.tools.commands.measure import Command
 from ripe.atlas.tools.exceptions import RipeAtlasToolsException
+from ripe.atlas.tools.settings import Configuration
 
 from .. import capture_sys_output
 
 
 class TestProbesCommand(unittest.TestCase):
+
+    CONF = "ripe.atlas.tools.commands.measure.conf"
+    KINDS = ("ping", "traceroute", "dns", "ssl", "ntp",)
 
     def setUp(self):
         self.cmd = Command()
@@ -46,10 +53,475 @@ class TestProbesCommand(unittest.TestCase):
                 self.cmd.run()
             self.assertEqual(
                 str(e.exception),
-                "DNS measurements require a query type, class, and argument"
+                "At a minimum, DNS measurements require a query argument."
             )
 
     def test_bad_type_argument(self):
         with capture_sys_output():
             with self.assertRaises(SystemExit):
                 self.cmd.init_args(["not-a-type"])
+
+    def test_dry_run(self):
+        with capture_sys_output() as (stdout, stderr):
+            self.cmd.init_args(["ping", "--target", "ripe.net", "--dry-run"])
+            self.cmd.run()
+            expected = (
+                "\n"
+                "Definitions:\n"
+                "================================================================================\n"
+                "target                    ripe.net\n"
+                "packet_interval           1000\n"
+                "description               \n"
+                "af                        4\n"
+                "packets                   3\n"
+                "size                      48\n"
+                "\n"
+                "Sources:\n"
+                "================================================================================\n"
+                "requested                 50\n"
+                "type                      area\n"
+                "value                     WW\n"
+                "tags\n"
+                "  include                 system-ipv4-works\n"
+                "  exclude                 \n"
+                "\n"
+            )
+            self.assertEqual(stdout.getvalue(), expected)
+
+        with capture_sys_output() as (stdout, stderr):
+            self.cmd.init_args([
+                "ping",
+                "--target", "ripe.net",
+                "--af", "6",
+                "--include-tag", "alpha",
+                "--include-tag", "bravo",
+                "--include-tag", "charlie",
+                "--exclude-tag", "delta",
+                "--exclude-tag", "echo",
+                "--exclude-tag", "foxtrot",
+                "--dry-run"
+            ])
+            self.cmd.run()
+            expected = (
+                "\n"
+                "Definitions:\n"
+                "================================================================================\n"
+                "target                    ripe.net\n"
+                "packet_interval           1000\n"
+                "description               \n"
+                "af                        6\n"
+                "packets                   3\n"
+                "size                      48\n"
+                "\n"
+                "Sources:\n"
+                "================================================================================\n"
+                "requested                 50\n"
+                "type                      area\n"
+                "value                     WW\n"
+                "tags\n"
+                "  include                 alpha, bravo, charlie\n"
+                "  exclude                 delta, echo, foxtrot\n"
+                "\n"
+            )
+            self.assertEqual(stdout.getvalue(), expected)
+
+    def test_clean_target(self):
+
+        with capture_sys_output():
+            self.cmd.init_args(["ping", "--target", "ripe.net"])
+            self.assertEqual(self.cmd.clean_target(), "ripe.net")
+
+        with capture_sys_output():
+            self.cmd.init_args(["dns"])
+            self.assertEqual(self.cmd.clean_target(), None)
+
+    @mock.patch("ripe.atlas.tools.commands.measure.conf", Configuration.DEFAULT)
+    def test_clean_protocol(self):
+
+        spec = Configuration.DEFAULT["specification"]["types"]
+
+        self.cmd.init_args(["traceroute", "--protocol", "UDP"])
+        self.assertEqual(self.cmd.clean_protocol(), "UDP")
+        self.assertEqual(self.cmd.arguments.protocol, "UDP")
+
+        self.cmd.init_args(["traceroute", "--protocol", "TCP"])
+        self.assertEqual(self.cmd.clean_protocol(), "TCP")
+        self.assertEqual(self.cmd.arguments.protocol, "TCP")
+
+        self.cmd.init_args(["traceroute", "--protocol", "ICMP"])
+        self.assertEqual(self.cmd.clean_protocol(), "ICMP")
+        self.assertEqual(self.cmd.arguments.protocol, "ICMP")
+
+        self.cmd.init_args(["traceroute"])
+        self.assertEqual(
+            self.cmd.clean_protocol(), spec["traceroute"]["protocol"])
+        self.assertEqual(
+            self.cmd.arguments.protocol, spec["traceroute"]["protocol"])
+
+        self.cmd.init_args(["dns", "--protocol", "UDP"])
+        self.assertEqual(self.cmd.clean_protocol(), "UDP")
+        self.assertEqual(self.cmd.arguments.protocol, "UDP")
+
+        self.cmd.init_args(["dns", "--protocol", "TCP"])
+        self.assertEqual(self.cmd.clean_protocol(), "TCP")
+        self.assertEqual(self.cmd.arguments.protocol, "TCP")
+
+        self.cmd.init_args(["dns"])
+        self.assertEqual(self.cmd.clean_protocol(), spec["dns"]["protocol"])
+        self.assertEqual(self.cmd.arguments.protocol, spec["dns"]["protocol"])
+
+        for kind in ("ping", "ssl", "ntp"):
+            with self.assertRaises(RipeAtlasToolsException) as e:
+                self.cmd.init_args([kind])
+                self.cmd.clean_protocol()
+            self.assertEqual(
+                str(e.exception),
+                "Measurements of type \"{}\" have no use for a "
+                "protocol value.".format(kind)
+            )
+
+    @mock.patch("ripe.atlas.tools.commands.measure.conf", Configuration.DEFAULT)
+    def test_clean_shared_option(self):
+
+        spec = Configuration.DEFAULT["specification"]["types"]
+        for kind in ("ping", "traceroute"):
+
+            self.cmd.init_args([kind, "--size", "25", "--packets", "6"])
+            self.assertEqual(self.cmd.clean_shared_option("ping", "size"), 25)
+            self.assertEqual(self.cmd.clean_shared_option("ping", "packets"), 6)
+
+            self.cmd.init_args([kind])
+            self.assertEqual(
+                self.cmd.clean_shared_option(kind, "size"), spec[kind]["size"])
+
+            self.cmd.init_args(["ping"])
+            self.assertEqual(
+                self.cmd.clean_shared_option(kind, "packets"),
+                spec[kind]["packets"]
+            )
+
+    @mock.patch("ripe.atlas.tools.commands.measure.conf", Configuration.DEFAULT)
+    def test_get_measurement_kwargs_ping(self):
+
+        spec = Configuration.DEFAULT["specification"]["types"]["ping"]
+
+        self.cmd.init_args([
+            "ping", "--target", "ripe.net"
+        ])
+        self.assertEqual(
+            self.cmd._get_measurement_kwargs(),
+            {
+                "af": Configuration.DEFAULT["specification"]["af"],
+                "description": Configuration.DEFAULT["specification"]["description"],
+                "target": "ripe.net",
+                "packets": spec["packets"],
+                "packet_interval": spec["packet-interval"],
+                "size": spec["size"]
+            }
+        )
+
+        self.cmd.init_args([
+            "ping",
+            "--target", "ripe.net",
+            "--af", "6",
+            "--description", "This is my description",
+            "--packets", "7",
+            "--packet-interval", "200",
+            "--size", "24"
+        ])
+        self.assertEqual(
+            self.cmd._get_measurement_kwargs(),
+            {
+                "af": 6,
+                "description": "This is my description",
+                "target": "ripe.net",
+                "packets": 7,
+                "packet_interval": 200,
+                "size": 24
+            }
+        )
+
+    @mock.patch("ripe.atlas.tools.commands.measure.conf", Configuration.DEFAULT)
+    def test_get_measurement_kwargs_traceroute(self):
+
+        spec = Configuration.DEFAULT["specification"]["types"]["traceroute"]
+
+        self.cmd.init_args([
+            "traceroute", "--target", "ripe.net"
+        ])
+        self.assertEqual(
+            self.cmd._get_measurement_kwargs(),
+            {
+                "af": Configuration.DEFAULT["specification"]["af"],
+                "description": Configuration.DEFAULT["specification"]["description"],
+                "target": "ripe.net",
+                "packets": spec["packets"],
+                "size": spec["size"],
+                "destination_option_size": spec["destination-option-size"],
+                "hop_by_hop_option_size": spec["hop-by-hop-option-size"],
+                "dont_fragment": spec["dont-fragment"],
+                "first_hop": spec["first-hop"],
+                "max_hops": spec["max-hops"],
+                "paris": spec["paris"],
+                "port": spec["port"],
+                "protocol": spec["protocol"],
+                "timeout": spec["timeout"]
+            }
+        )
+
+        self.cmd.init_args([
+            "traceroute",
+            "--af", "6",
+            "--description", "This is my description",
+            "--target", "ripe.net",
+            "--packets", "7",
+            "--size", "24",
+            "--destination-option-size", "12",
+            "--hop-by-hop-option-size", "13",
+            "--dont-fragment",
+            "--first-hop", "2",
+            "--max-hops", "5",
+            "--paris", "8",
+            "--port", "123",
+            "--protocol", "TCP",
+            "--timeout", "1500"
+        ])
+        self.assertEqual(
+            self.cmd._get_measurement_kwargs(),
+            {
+                "af": 6,
+                "description": "This is my description",
+                "target": "ripe.net",
+                "packets": 7,
+                "size": 24,
+                "destination_option_size": 12,
+                "hop_by_hop_option_size": 13,
+                "dont_fragment": True,
+                "first_hop": 2,
+                "max_hops": 5,
+                "paris": 8,
+                "port": 123,
+                "protocol": "TCP",
+                "timeout": 1500
+            }
+        )
+
+    @mock.patch("ripe.atlas.tools.commands.measure.conf", Configuration.DEFAULT)
+    def test_get_measurement_kwargs_dns(self):
+
+        spec = Configuration.DEFAULT["specification"]["types"]["dns"]
+
+        self.cmd.init_args([
+            "dns", "--query-argument", "ripe.net"
+        ])
+        self.assertEqual(
+            self.cmd._get_measurement_kwargs(),
+            {
+                "af": Configuration.DEFAULT["specification"]["af"],
+                "description": Configuration.DEFAULT["specification"]["description"],
+                "query_class": spec["query-class"],
+                "query_type": spec["query-type"],
+                "query_argument": "ripe.net",
+                "set_cd_bit": spec["set-cd-bit"],
+                "set_do_bit": spec["set-do-bit"],
+                "set_rd_bit": spec["set-rd-bit"],
+                "set_nsid_bit": spec["set-nsid-bit"],
+                "protocol": spec["protocol"],
+                "retry": spec["retry"],
+                "udp_payload_size": spec["udp-payload-size"],
+                "use_probe_resolver": True,
+            }
+        )
+
+        self.cmd.init_args([
+            "dns",
+            "--af", "6",
+            "--description", "This is my description",
+            "--target", "non-existent-dns.ripe.net",
+            "--query-class", "CHAOS",
+            "--query-type", "SOA",
+            "--query-argument", "some arbitrary string",
+            "--set-cd-bit",
+            "--set-do-bit",
+            "--set-rd-bit",
+            "--set-nsid-bit",
+            "--protocol", "TCP",
+            "--retry", "2",
+            "--udp-payload-size", "5"
+        ])
+        self.assertEqual(
+            self.cmd._get_measurement_kwargs(),
+            {
+                "af": 6,
+                "description": "This is my description",
+                "target": "non-existent-dns.ripe.net",
+                "query_class": "CHAOS",
+                "query_type": "SOA",
+                "query_argument": "some arbitrary string",
+                "set_cd_bit": True,
+                "set_do_bit": True,
+                "set_rd_bit": True,
+                "set_nsid_bit": True,
+                "protocol": "TCP",
+                "retry": 2,
+                "udp_payload_size": 5,
+                "use_probe_resolver": False
+            }
+        )
+
+    @mock.patch("ripe.atlas.tools.commands.measure.conf", Configuration.DEFAULT)
+    def test_get_source_kwargs(self):
+
+        spec = Configuration.DEFAULT["specification"]
+
+        for kind in self.KINDS:
+
+            tags = spec["tags"]["ipv{}".format(spec["af"])]
+            includes = tags[kind]["include"] + tags["all"]["include"]
+            excludes = tags[kind]["exclude"] + tags["all"]["exclude"]
+
+            self.cmd.init_args([kind])
+            self.assertEqual(self.cmd._get_source_kwargs(), {
+                "requested": spec["source"]["requested"],
+                "type": spec["source"]["type"],
+                "value": spec["source"]["value"],
+                "tags": {"include": includes, "exclude": excludes}
+            })
+
+            self.cmd.init_args([
+                kind,
+                "--probes", "10",
+                "--from-country", "ca"
+            ])
+            self.assertEqual(self.cmd._get_source_kwargs(), {
+                "requested": 10,
+                "type": "country",
+                "value": "CA",
+                "tags": {"include": includes, "exclude": excludes}
+            })
+
+            for area in ("WW", "West", "North-Central", "South-Central",
+                         "North-East", "South-East"):
+                self.cmd.init_args([
+                    kind,
+                    "--probes", "10",
+                    "--from-area", area
+                ])
+                self.assertEqual(self.cmd._get_source_kwargs(), {
+                    "requested": 10,
+                    "type": "area",
+                    "value": area,
+                    "tags": {"include": includes, "exclude": excludes}
+                })
+
+            self.cmd.init_args([
+                kind,
+                "--probes", "10",
+                "--from-prefix", "1.2.3.0/22"
+            ])
+            self.assertEqual(self.cmd._get_source_kwargs(), {
+                "requested": 10,
+                "type": "prefix",
+                "value": "1.2.3.0/22",
+                "tags": {"include": includes, "exclude": excludes}
+            })
+
+            self.cmd.init_args([
+                kind,
+                "--probes", "10",
+                "--from-asn", "3333"
+            ])
+            self.assertEqual(self.cmd._get_source_kwargs(), {
+                "requested": 10,
+                "type": "asn",
+                "value": 3333,
+                "tags": {"include": includes, "exclude": excludes}
+            })
+
+            # Try 20 permutations of probe lists
+            for __ in range(0, 20):
+                requested = randint(1, 500)
+                selection = [str(randint(0, 5000)) for _ in range(0, 100)]
+                self.cmd.init_args([
+                    kind,
+                    "--probes", str(requested),
+                    "--from-probes", ",".join(selection)
+                ])
+                self.assertEqual(self.cmd._get_source_kwargs(), {
+                    "requested": requested,
+                    "type": "probes",
+                    "value": ",".join(selection),
+                    "tags": {"include": includes, "exclude": excludes}
+                })
+
+            self.cmd.init_args([
+                kind,
+                "--probes", "10",
+                "--from-measurement", "1001"
+            ])
+            self.assertEqual(self.cmd._get_source_kwargs(), {
+                "requested": 10,
+                "type": "msm",
+                "value": 1001,
+                "tags": {"include": includes, "exclude": excludes}
+            })
+
+            self.cmd.init_args([
+                kind,
+                "--include-tag", "tag-to-include",
+                "--exclude-tag", "tag-to-exclude"
+            ])
+            self.assertEqual(self.cmd._get_source_kwargs(), {
+                "requested": spec["source"]["requested"],
+                "type": spec["source"]["type"],
+                "value": spec["source"]["value"],
+                "tags": {
+                    "include": ["tag-to-include"],
+                    "exclude": ["tag-to-exclude"]
+                }
+            })
+
+    def test_get_af(self):
+
+        conf = copy.deepcopy(Configuration.DEFAULT)
+        conf["specification"]["af"] = 100
+
+        with mock.patch(self.CONF, conf):
+            for kind in self.KINDS:
+
+                for af in (4, 6):
+                    self.cmd.init_args([kind, "--af", str(af)])
+                    self.assertEqual(self.cmd._get_af(), af)
+
+                self.cmd.init_args([kind, "--target", "1.2.3.4"])
+                self.assertEqual(self.cmd._get_af(), 4)
+
+                self.cmd.init_args([kind, "--target", "1:2:3:4:5:6:7:8"])
+                self.assertEqual(self.cmd._get_af(), 6)
+
+                self.cmd.init_args([kind, "--target", "1.2.3.4.5"])
+                self.assertEqual(
+                    self.cmd._get_af(),
+                    conf["specification"]["af"]
+                )
+
+    def test_handle_api_error(self):
+
+        message = (
+            "There was a problem communicating with the RIPE Atlas "
+            "infrastructure.  The message given was:\n\n  {}"
+        )
+
+        with self.assertRaises(RipeAtlasToolsException) as e:
+            self.cmd._handle_api_error("This is a plain text error")
+        self.assertEqual(
+            str(e.exception),
+            message.format("This is a plain text error")
+        )
+
+        with self.assertRaises(RipeAtlasToolsException) as e:
+            self.cmd._handle_api_error({"detail": "This is a formatted error"})
+        self.assertEqual(
+            str(e.exception),
+            message.format("This is a formatted error")
+        )

--- a/tests/commands/measure.py
+++ b/tests/commands/measure.py
@@ -1,0 +1,55 @@
+import unittest
+
+# Python 3 comes with mock in unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from ripe.atlas.tools.commands.measure import Command
+from ripe.atlas.tools.exceptions import RipeAtlasToolsException
+
+from .. import capture_sys_output
+
+
+class TestProbesCommand(unittest.TestCase):
+
+    def setUp(self):
+        self.cmd = Command()
+        self.maxDiff = None
+
+    def test_no_arguments(self):
+        with capture_sys_output() as (stdout, stderr):
+            with self.assertRaises(SystemExit):
+                self.cmd.init_args([])
+                self.cmd.run()
+            self.assertEqual(
+                "ripe-atlas measure: error: too few arguments",
+                stderr.getvalue().split("\n")[-2]
+            )
+
+    def test_types_no_arguments(self):
+
+        for kind in ("ping", "traceroute", "ssl", "ntp",):
+            with capture_sys_output():
+                with self.assertRaises(RipeAtlasToolsException) as e:
+                    self.cmd.init_args([kind])
+                    self.cmd.run()
+                self.assertEqual(
+                    str(e.exception),
+                    "You must specify a target for that kind of measurement"
+                )
+
+        with capture_sys_output():
+            with self.assertRaises(RipeAtlasToolsException) as e:
+                self.cmd.init_args(["dns"])
+                self.cmd.run()
+            self.assertEqual(
+                str(e.exception),
+                "DNS measurements require a query type, class, and argument"
+            )
+
+    def test_bad_type_argument(self):
+        with capture_sys_output():
+            with self.assertRaises(SystemExit):
+                self.cmd.init_args(["not-a-type"])

--- a/tests/commands/measure.py
+++ b/tests/commands/measure.py
@@ -13,10 +13,10 @@ from ripe.atlas.tools.commands.measure import Command
 from ripe.atlas.tools.exceptions import RipeAtlasToolsException
 from ripe.atlas.tools.settings import Configuration
 
-from .. import capture_sys_output
+from ..base import capture_sys_output
 
 
-class TestProbesCommand(unittest.TestCase):
+class TestMeasureCommand(unittest.TestCase):
 
     CONF = "ripe.atlas.tools.commands.measure.conf"
     KINDS = ("ping", "traceroute", "dns", "ssl", "ntp",)

--- a/tests/commands/measurements.py
+++ b/tests/commands/measurements.py
@@ -1,14 +1,23 @@
+import collections
+import datetime
 import sys
+import unittest
 
+# Python 3 try/catches
 try:
     from unittest import mock
 except ImportError:
     import mock
 
-import unittest
-from collections import namedtuple
+try:
+    from cStringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from ripe.atlas.tools.commands.measurements import Command
+from ripe.atlas.tools.exceptions import RipeAtlasToolsException
+
+from .. import capture_sys_output
 
 
 class FakeGen(object):
@@ -16,18 +25,38 @@ class FakeGen(object):
     A rip-off of the code used for testing probes, but a little prettier.
     """
 
-    Measurement = namedtuple(
-        "Measurement",
-        ("id", "type", "status", "status_id", "meta_data", "destination_name")
-    )
+    Measurement = collections.namedtuple("Measurement", (
+        "id", "type", "status", "status_id", "meta_data", "destination_name",
+        "description"
+    ))
 
     def __init__(self):
         self.data = [
-            self.Measurement(id=1, type="ping", status="Ongoing", status_id=2, meta_data={"status": {"name": "Ongoing", "id": 2}}, destination_name="Name 1",),
-            self.Measurement(id=2, type="ping", status="Ongoing", status_id=2, meta_data={"status": {"name": "Ongoing", "id": 2}}, destination_name="Name 2",),
-            self.Measurement(id=3, type="ping", status="Ongoing", status_id=2, meta_data={"status": {"name": "Ongoing", "id": 2}}, destination_name="Name 3",),
-            self.Measurement(id=4, type="ping", status="Ongoing", status_id=2, meta_data={"status": {"name": "Ongoing", "id": 2}}, destination_name="Name 4",),
-            self.Measurement(id=5, type="ping", status="Ongoing", status_id=2, meta_data={"status": {"name": "Ongoing", "id": 2}}, destination_name="Name 5",),
+            self.Measurement(
+                id=1, type="ping", status="Ongoing", status_id=2,
+                meta_data={"status": {"name": "Ongoing", "id": 2}},
+                destination_name="Name 1", description="Description 1",
+            ),
+            self.Measurement(
+                id=2, type="ping", status="Ongoing", status_id=2,
+                meta_data={"status": {"name": "Ongoing", "id": 2}},
+                destination_name="Name 2", description="Description 2",
+            ),
+            self.Measurement(
+                id=3, type="ping", status="Ongoing", status_id=2,
+                meta_data={"status": {"name": "Ongoing", "id": 2}},
+                destination_name="Name 3", description="Description 3",
+            ),
+            self.Measurement(
+                id=4, type="ping", status="Ongoing", status_id=2,
+                meta_data={"status": {"name": "Ongoing", "id": 2}},
+                destination_name="Name 4", description="Description 4",
+            ),
+            self.Measurement(
+                id=5, type="ping", status="Ongoing", status_id=2,
+                meta_data={"status": {"name": "Ongoing", "id": 2}},
+                destination_name="Name 5", description="Description 5",
+            ),
         ]
         self.total_count = 5
 
@@ -52,6 +81,113 @@ class TestMeasurementsCommand(unittest.TestCase):
 
     @mock.patch("ripe.atlas.tools.commands.measurements.MeasurementRequest")
     def test_with_empty_args(self, mock_request):
+
         mock_request.return_value = FakeGen()
+
+        with capture_sys_output() as (stdout, stderr):
+            self.cmd.init_args([])
+            self.cmd.run()
+
+        expected_content = (
+            "\n"
+            "Id      Type       Description                                           Status\n"
+            "===============================================================================\n"
+            "1       ping       Description 1                                        Ongoing\n"
+            "2       ping       Description 2                                        Ongoing\n"
+            "3       ping       Description 3                                        Ongoing\n"
+            "4       ping       Description 4                                        Ongoing\n"
+            "5       ping       Description 5                                        Ongoing\n"
+            "===============================================================================\n"
+            "                                              Showing 5 of 5 total measurements\n"
+            "\n"
+        )
+        self.assertEqual(
+            set(stdout.getvalue().split("\n")),
+            set(expected_content.split("\n"))
+        )
+        self.assertEqual(
+            self.cmd.arguments.field, ("id", "type", "description", "status"))
+
+    @mock.patch("ripe.atlas.tools.commands.measurements.MeasurementRequest")
+    def test_get_line_items(self, mock_request):
+
         self.cmd.init_args([])
-        self.cmd.run()
+        self.cmd.run()  # Forces the defaults
+        self.assertEqual(
+            self.cmd._get_line_items(FakeGen.Measurement(
+                id=1, type="ping", status="Ongoing", status_id=2,
+                meta_data={"status": {"name": "Ongoing", "id": 2}},
+                destination_name="Name 1", description="Description 1",
+            )),
+            [1, "ping", "Description 1", "Ongoing"]
+        )
+
+        self.cmd.init_args([
+            "--field", "id",
+            "--field", "status"
+        ])
+        self.assertEqual(
+            self.cmd._get_line_items(FakeGen.Measurement(
+                id=1, type="ping", status="Ongoing", status_id=2,
+                meta_data={"status": {"name": "Ongoing", "id": 2}},
+                destination_name="Name 1", description="Description 1",
+            )),
+            [1, "Ongoing"]
+        )
+
+        self.cmd.init_args([
+            "--field", "url",
+        ])
+        self.assertEqual(
+            self.cmd._get_line_items(FakeGen.Measurement(
+                id=1, type="ping", status="Ongoing", status_id=2,
+                meta_data={"status": {"name": "Ongoing", "id": 2}},
+                destination_name="Name 1", description="Description 1",
+            )),
+            ["https://atlas.ripe.net/measurements/1/"]
+        )
+
+    def test_get_filters(self):
+        self.cmd.init_args([
+            "--search", "the force is strong with this one",
+            "--status", "ongoing",
+            "--af", "6",
+            "--type", "ping",
+            "--started-before", "2015-01-01",
+            "--started-after", "2014-01-01",
+            "--stopped-before", "2015-01-01",
+            "--stopped-after", "2014-01-01",
+        ])
+        self.assertEqual(self.cmd._get_filters(), {
+            "search": "the force is strong with this one",
+            "status__in": (2,),
+            "af": 6,
+            "type": "ping",
+            "start_time__lt": datetime.datetime(2015, 1, 1),
+            "start_time__gt": datetime.datetime(2014, 1, 1),
+            "stop_time__lt": datetime.datetime(2015, 1, 1),
+            "stop_time__gt": datetime.datetime(2014, 1, 1),
+        })
+
+    def test_get_colour_from_status(self):
+        self.assertEqual(self.cmd._get_colour_from_status(0), "blue")
+        self.assertEqual(self.cmd._get_colour_from_status(1), "blue")
+        self.assertEqual(self.cmd._get_colour_from_status(2), "green")
+        self.assertEqual(self.cmd._get_colour_from_status(4), "yellow")
+        self.assertEqual(self.cmd._get_colour_from_status(5), "red")
+        self.assertEqual(self.cmd._get_colour_from_status(6), "red")
+        self.assertEqual(self.cmd._get_colour_from_status(7), "red")
+        self.assertEqual(self.cmd._get_colour_from_status("XXX"), "white")
+
+    def test_fail_arguments(self):
+        expected_failures = (
+            ("--status", "not a status"),
+            ("--not-an-option",),
+            ("--af", "5"),
+            ("--type", "not a type"),
+            ("--field", "not a field"),
+        )
+        for failure in expected_failures:
+            with capture_sys_output() as (stdout, stderr):
+                with self.assertRaises(SystemExit):
+                    self.cmd.init_args(failure)

--- a/tests/commands/measurements.py
+++ b/tests/commands/measurements.py
@@ -1,21 +1,14 @@
 import collections
 import datetime
-import sys
 import unittest
 
-# Python 3 try/catches
+# Python 3 comes with mock in unittest
 try:
     from unittest import mock
 except ImportError:
     import mock
 
-try:
-    from cStringIO import StringIO
-except ImportError:
-    from io import StringIO
-
 from ripe.atlas.tools.commands.measurements import Command
-from ripe.atlas.tools.exceptions import RipeAtlasToolsException
 
 from .. import capture_sys_output
 

--- a/tests/commands/measurements.py
+++ b/tests/commands/measurements.py
@@ -10,7 +10,7 @@ except ImportError:
 
 from ripe.atlas.tools.commands.measurements import Command
 
-from .. import capture_sys_output
+from ..base import capture_sys_output
 
 
 class FakeGen(object):


### PR DESCRIPTION
The tests here cover all methods of the `measure` command except for `run()`, `create()`, and `stream()`.  I'm also including a bunch of fixes that I found I had to do once I got the tests running.