### PR TITLE
Add report, measure, and measurements to the complete list of tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,19 @@
 from .aggregators import TestAggregators
-from .commands import TestProbesCommand
+from .commands import (
+    TestProbesCommand,
+    TestMeasureCommand,
+    TestMeasurementsCommand,
+    TestReportCommand
+)
 from .helpers import TestArgumentTypeHelper
 from .renderers import TestPingRenderer
 
 
-__all__ = [TestAggregators, TestProbesCommand, TestPingRenderer]
+__all__ = [
+    TestAggregators,
+    TestProbesCommand,
+    TestMeasureCommand,
+    TestMeasurementsCommand,
+    TestReportCommand,
+    TestPingRenderer,
+]


### PR DESCRIPTION
This will cause a tests failure, since it looks like the `report` tests are a little broken, but this PR fixes the bug that caused us to miss this in the first place ;-)