### PR TITLE
Tests/measure

### DIFF
--- a/ripe/atlas/tools/commands/base.py
+++ b/ripe/atlas/tools/commands/base.py
@@ -27,12 +27,13 @@ class Command(object):
             prog="ripe-atlas {}".format(self.NAME)
         )
 
-    def init_args(self, parser_args=None):
+    def init_args(self, args=None):
         """
         Initialises all parse arguments and makes them available to the class.
         """
 
-        args = parser_args if not None else sys.argv[1:]
+        if args is None:
+            args = sys.argv[1:]
 
         self.arguments = self.parser.parse_args(
             self._modify_parser_args(args))

--- a/ripe/atlas/tools/commands/base.py
+++ b/ripe/atlas/tools/commands/base.py
@@ -27,15 +27,13 @@ class Command(object):
             prog="ripe-atlas {}".format(self.NAME)
         )
 
-        self.add_arguments()
-
     def init_args(self, parser_args=None):
         """
         Initialises all parse arguments and makes them available to the class.
         """
 
         self.arguments = self.parser.parse_args(
-            self._modify_parser_args(parser_args or sys.argv))
+            self._modify_parser_args(parser_args or sys.argv[1:]))
 
     def run(self):
         raise NotImplemented()
@@ -62,6 +60,12 @@ class Command(object):
         use-case we're trying to solve here is popping a secondary argument off
         of the list and/or appending `--help` in some circumstances.
         """
+
+        if not args:
+            args.append("--help")
+
+        self.add_arguments()
+
         return args
 
     def ok(self, message):
@@ -128,3 +132,10 @@ class TabularFieldsMixin(object):
 
     def _get_filter_key_value_pair(self, k, v):
         return k.capitalize().replace("__", " "), v
+
+
+class Factory(object):
+
+    @classmethod
+    def build(cls, *args, **kwargs):
+        return object()

--- a/ripe/atlas/tools/commands/base.py
+++ b/ripe/atlas/tools/commands/base.py
@@ -34,10 +34,8 @@ class Command(object):
         Initialises all parse arguments and makes them available to the class.
         """
 
-        if parser_args is None:
-            self.arguments = self.parser.parse_args()
-        else:
-            self.arguments = self.parser.parse_args(parser_args)
+        self.arguments = self.parser.parse_args(
+            self._modify_parser_args(parser_args or sys.argv))
 
     def run(self):
         raise NotImplemented()
@@ -56,6 +54,15 @@ class Command(object):
 
         """
         pass
+
+    def _modify_parser_args(self, args):
+        """
+        A modifier hook that can be overridden in the child class to allow that
+        class to manipulate the arguments before being parsed.  The common
+        use-case we're trying to solve here is popping a secondary argument off
+        of the list and/or appending `--help` in some circumstances.
+        """
+        return args
 
     def ok(self, message):
         sys.stdout.write("\n{}\n\n".format(colourise(message, "green")))

--- a/ripe/atlas/tools/commands/base.py
+++ b/ripe/atlas/tools/commands/base.py
@@ -32,8 +32,10 @@ class Command(object):
         Initialises all parse arguments and makes them available to the class.
         """
 
+        args = parser_args if not None else sys.argv[1:]
+
         self.arguments = self.parser.parse_args(
-            self._modify_parser_args(parser_args or sys.argv[1:]))
+            self._modify_parser_args(args))
 
     def run(self):
         raise NotImplemented()
@@ -60,9 +62,6 @@ class Command(object):
         use-case we're trying to solve here is popping a secondary argument off
         of the list and/or appending `--help` in some circumstances.
         """
-
-        if not args:
-            args.append("--help")
 
         self.add_arguments()
 

--- a/ripe/atlas/tools/commands/measure.py
+++ b/ripe/atlas/tools/commands/measure.py
@@ -58,6 +58,9 @@ class Command(BaseCommand):
             raise RipeAtlasToolsException(error)
         self._type = args.pop(0)
 
+        if not args:
+            args.append("--help")
+
         return BaseCommand._modify_parser_args(self, args)
 
     def add_arguments(self):

--- a/ripe/atlas/tools/commands/measure.py
+++ b/ripe/atlas/tools/commands/measure.py
@@ -642,15 +642,20 @@ class Factory(BaseFactory):
         "ping": PingMeasureCommand,
         "traceroute": TracerouteMeasureCommand,
         "dns": DnsMeasureCommand,
+        "ssl": SslMeasureCommand,
+        "ntp": NtpMeasureCommand,
     }
 
     def __init__(self):
 
-        self.build_class = Command
+        self.build_class = None
         if len(sys.argv) >= 2:
-            self.build_class = self.TYPES.get(
-                sys.argv[1].lower(),
-                self.build_class
+            self.build_class = self.TYPES.get(sys.argv[1].lower())
+
+        if not self.build_class:
+            raise RipeAtlasToolsException(
+                "The measurement type you requested is invalid.  Please choose "
+                "one of {}.".format(", ".join(self.TYPES.keys()))
             )
 
     def create(self, *args, **kwargs):

--- a/ripe/atlas/tools/commands/measure.py
+++ b/ripe/atlas/tools/commands/measure.py
@@ -653,5 +653,5 @@ class Factory(BaseFactory):
                 self.build_class
             )
 
-    def build(self, *args, **kwargs):
+    def create(self, *args, **kwargs):
         return self.build_class(*args, **kwargs)

--- a/scripts/ripe-atlas
+++ b/scripts/ripe-atlas
@@ -75,8 +75,14 @@ class RipeAtlas(object):
                 [self.command]
             )
 
+            #
+            # If the imported module contains a `Factory` class, execute that
+            # to get the `cmd` we're going to use.  Otherwise, we expect there
+            # to be a `Command` class in there.
+            #
+
             if hasattr(module, "Factory"):
-                cmd = module.Factory(*self.args, **self.kwargs).build()
+                cmd = module.Factory(*self.args, **self.kwargs).create()
             else:
                 cmd = module.Command(*self.args, **self.kwargs)
 

--- a/scripts/ripe-atlas
+++ b/scripts/ripe-atlas
@@ -68,12 +68,18 @@ class RipeAtlas(object):
 
         try:
 
-            cmd = __import__(
+            module = __import__(
                 "ripe.atlas.tools.commands." + self.command,
                 globals(),
                 locals(),
                 [self.command]
-            ).Command(*self.args, **self.kwargs)
+            )
+
+            if hasattr(module, "Factory"):
+                cmd = module.Factory(*self.args, **self.kwargs).build()
+            else:
+                cmd = module.Command(*self.args, **self.kwargs)
+
             cmd.init_args()
             cmd.run()
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,19 @@
 from .aggregators import TestAggregators
-from .commands import TestProbesCommand
+from .commands import (
+    TestProbesCommand,
+    TestMeasureCommand,
+    TestMeasurementsCommand,
+    TestReportCommand
+)
 from .helpers import TestArgumentTypeHelper
 from .renderers import TestPingRenderer
 
 
-__all__ = [TestAggregators, TestProbesCommand, TestPingRenderer]
+__all__ = [
+    TestAggregators,
+    TestProbesCommand,
+    TestMeasureCommand,
+    TestMeasurementsCommand,
+    TestReportCommand,
+    TestPingRenderer,
+]

--- a/tests/commands/measure.py
+++ b/tests/commands/measure.py
@@ -82,7 +82,10 @@ class TestMeasureCommand(unittest.TestCase):
                 "  exclude                 \n"
                 "\n"
             )
-            self.assertEqual(stdout.getvalue(), expected)
+            self.assertEqual(
+                set(stdout.getvalue().split("\n")),
+                set(expected.split("\n"))
+            )
 
         with capture_sys_output() as (stdout, stderr):
             cmd = PingMeasureCommand()
@@ -120,7 +123,10 @@ class TestMeasureCommand(unittest.TestCase):
                 "  exclude                 delta, echo, foxtrot\n"
                 "\n"
             )
-            self.assertEqual(stdout.getvalue(), expected)
+            self.assertEqual(
+                set(stdout.getvalue().split("\n")),
+                set(expected.split("\n"))
+            )
 
     def test_clean_target(self):
 

--- a/tests/commands/measure.py
+++ b/tests/commands/measure.py
@@ -532,7 +532,7 @@ class TestMeasureCommand(unittest.TestCase):
 
         with capture_sys_output() as (stdout, stderr):
             with self.assertRaises(SystemExit):
-                self.cmd.init_args(["not-a-type"])
+                self.cmd.init_args(["ping", "not-a-type"])
             self.assertEqual(
                 stderr.getvalue().split("\n")[-2],
                 "ripe-atlas measure: error: argument type: invalid choice: "
@@ -542,7 +542,7 @@ class TestMeasureCommand(unittest.TestCase):
 
         with capture_sys_output() as (stdout, stderr):
             with self.assertRaises(SystemExit):
-                self.cmd.init_args(["--renderer", "not-a-renderer"])
+                self.cmd.init_args(["ping", "--renderer", "not-a-renderer"])
             self.assertTrue(stderr.getvalue().split("\n")[-2].startswith(
                 "ripe-atlas measure: error: argument --renderer: invalid "
                 "choice: 'not-a-renderer' (choose from"
@@ -550,7 +550,7 @@ class TestMeasureCommand(unittest.TestCase):
 
         with capture_sys_output() as (stdout, stderr):
             with self.assertRaises(SystemExit):
-                self.cmd.init_args(["--af", "5"])
+                self.cmd.init_args(["ping", "--af", "5"])
             self.assertEqual(
                 stderr.getvalue().split("\n")[-2],
                 "ripe-atlas measure: error: argument --af: invalid choice: 5 "
@@ -559,7 +559,7 @@ class TestMeasureCommand(unittest.TestCase):
 
         with capture_sys_output() as (stdout, stderr):
             with self.assertRaises(SystemExit):
-                self.cmd.init_args(["--target", "not a target"])
+                self.cmd.init_args(["ping", "--target", "not a target"])
             self.assertEqual(
                 stderr.getvalue().split("\n")[-2],
                 "ripe-atlas measure: error: argument --target: "
@@ -569,14 +569,14 @@ class TestMeasureCommand(unittest.TestCase):
 
         with capture_sys_output() as (stdout, stderr):
             with self.assertRaises(SystemExit):
-                self.cmd.init_args(["--from-area", "not an area"])
+                self.cmd.init_args(["ping", "--from-area", "not an area"])
             self.assertTrue(stderr.getvalue().split("\n")[-2].startswith(
                 "ripe-atlas measure: error: argument --from-area: invalid "
                 "choice:"))
 
         with capture_sys_output() as (stdout, stderr):
             with self.assertRaises(SystemExit):
-                self.cmd.init_args(["--from-probes", "0,50000"])
+                self.cmd.init_args(["ping", "--from-probes", "0,50000"])
             self.assertEqual(
                 stderr.getvalue().split("\n")[-2],
                 "ripe-atlas measure: error: argument --from-probes: 0 "
@@ -599,11 +599,20 @@ class TestMeasureCommand(unittest.TestCase):
 
         with capture_sys_output() as (stdout, stderr):
             with self.assertRaises(SystemExit):
-                self.cmd.init_args(["--protocol", "invalid"])
+                self.cmd.init_args(["traceroute", "--protocol", "invalid"])
             self.assertEqual(
                 stderr.getvalue().split("\n")[-2],
                 "ripe-atlas measure: error: argument --protocol: invalid "
                 "choice: 'invalid' (choose from 'ICMP', 'UDP', 'TCP')"
+            )
+
+        with capture_sys_output() as (stdout, stderr):
+            with self.assertRaises(SystemExit):
+                self.cmd.init_args(["dns", "--protocol", "invalid"])
+            self.assertEqual(
+                stderr.getvalue().split("\n")[-2],
+                "ripe-atlas measure: error: argument --protocol: invalid "
+                "choice: 'invalid' (choose from 'UDP', 'TCP')"
             )
 
         min_options = {

--- a/tests/commands/measurements.py
+++ b/tests/commands/measurements.py
@@ -69,17 +69,15 @@ class FakeGen(object):
 
 class TestMeasurementsCommand(unittest.TestCase):
 
-    def setUp(self):
-        self.cmd = Command()
-
     @mock.patch("ripe.atlas.tools.commands.measurements.MeasurementRequest")
     def test_with_empty_args(self, mock_request):
 
         mock_request.return_value = FakeGen()
 
+        cmd = Command()
         with capture_sys_output() as (stdout, stderr):
-            self.cmd.init_args([])
-            self.cmd.run()
+            cmd.init_args([])
+            cmd.run()
 
         expected_content = (
             "\n"
@@ -99,15 +97,16 @@ class TestMeasurementsCommand(unittest.TestCase):
             set(expected_content.split("\n"))
         )
         self.assertEqual(
-            self.cmd.arguments.field, ("id", "type", "description", "status"))
+            cmd.arguments.field, ("id", "type", "description", "status"))
 
     @mock.patch("ripe.atlas.tools.commands.measurements.MeasurementRequest")
     def test_get_line_items(self, mock_request):
 
-        self.cmd.init_args([])
-        self.cmd.run()  # Forces the defaults
+        cmd = Command()
+        cmd.init_args([])
+        cmd.run()  # Forces the defaults
         self.assertEqual(
-            self.cmd._get_line_items(FakeGen.Measurement(
+            cmd._get_line_items(FakeGen.Measurement(
                 id=1, type="ping", status="Ongoing", status_id=2,
                 meta_data={"status": {"name": "Ongoing", "id": 2}},
                 destination_name="Name 1", description="Description 1",
@@ -115,12 +114,13 @@ class TestMeasurementsCommand(unittest.TestCase):
             [1, "ping", "Description 1", "Ongoing"]
         )
 
-        self.cmd.init_args([
+        cmd = Command()
+        cmd.init_args([
             "--field", "id",
             "--field", "status"
         ])
         self.assertEqual(
-            self.cmd._get_line_items(FakeGen.Measurement(
+            cmd._get_line_items(FakeGen.Measurement(
                 id=1, type="ping", status="Ongoing", status_id=2,
                 meta_data={"status": {"name": "Ongoing", "id": 2}},
                 destination_name="Name 1", description="Description 1",
@@ -128,11 +128,12 @@ class TestMeasurementsCommand(unittest.TestCase):
             [1, "Ongoing"]
         )
 
-        self.cmd.init_args([
+        cmd = Command()
+        cmd.init_args([
             "--field", "url",
         ])
         self.assertEqual(
-            self.cmd._get_line_items(FakeGen.Measurement(
+            cmd._get_line_items(FakeGen.Measurement(
                 id=1, type="ping", status="Ongoing", status_id=2,
                 meta_data={"status": {"name": "Ongoing", "id": 2}},
                 destination_name="Name 1", description="Description 1",
@@ -141,7 +142,8 @@ class TestMeasurementsCommand(unittest.TestCase):
         )
 
     def test_get_filters(self):
-        self.cmd.init_args([
+        cmd = Command()
+        cmd.init_args([
             "--search", "the force is strong with this one",
             "--status", "ongoing",
             "--af", "6",
@@ -151,7 +153,7 @@ class TestMeasurementsCommand(unittest.TestCase):
             "--stopped-before", "2015-01-01",
             "--stopped-after", "2014-01-01",
         ])
-        self.assertEqual(self.cmd._get_filters(), {
+        self.assertEqual(cmd._get_filters(), {
             "search": "the force is strong with this one",
             "status__in": (2,),
             "af": 6,
@@ -163,14 +165,15 @@ class TestMeasurementsCommand(unittest.TestCase):
         })
 
     def test_get_colour_from_status(self):
-        self.assertEqual(self.cmd._get_colour_from_status(0), "blue")
-        self.assertEqual(self.cmd._get_colour_from_status(1), "blue")
-        self.assertEqual(self.cmd._get_colour_from_status(2), "green")
-        self.assertEqual(self.cmd._get_colour_from_status(4), "yellow")
-        self.assertEqual(self.cmd._get_colour_from_status(5), "red")
-        self.assertEqual(self.cmd._get_colour_from_status(6), "red")
-        self.assertEqual(self.cmd._get_colour_from_status(7), "red")
-        self.assertEqual(self.cmd._get_colour_from_status("XXX"), "white")
+        cmd = Command()
+        self.assertEqual(cmd._get_colour_from_status(0), "blue")
+        self.assertEqual(cmd._get_colour_from_status(1), "blue")
+        self.assertEqual(cmd._get_colour_from_status(2), "green")
+        self.assertEqual(cmd._get_colour_from_status(4), "yellow")
+        self.assertEqual(cmd._get_colour_from_status(5), "red")
+        self.assertEqual(cmd._get_colour_from_status(6), "red")
+        self.assertEqual(cmd._get_colour_from_status(7), "red")
+        self.assertEqual(cmd._get_colour_from_status("XXX"), "white")
 
     def test_fail_arguments(self):
         expected_failures = (
@@ -181,6 +184,6 @@ class TestMeasurementsCommand(unittest.TestCase):
             ("--field", "not a field"),
         )
         for failure in expected_failures:
-            with capture_sys_output() as (stdout, stderr):
+            with capture_sys_output():
                 with self.assertRaises(SystemExit):
-                    self.cmd.init_args(failure)
+                    Command().init_args(failure)

--- a/tests/commands/report.py
+++ b/tests/commands/report.py
@@ -11,6 +11,8 @@ from ripe.atlas.tools.commands.report import Command
 from ripe.atlas.tools.exceptions import RipeAtlasToolsException
 from ripe.atlas.tools.renderers import Renderer
 
+from ..base import capture_sys_output
+
 
 class TestReportCommand(unittest.TestCase):
 
@@ -31,33 +33,38 @@ class TestReportCommand(unittest.TestCase):
 
     def test_with_empty_args(self):
         """User passes no args, should fail with SystemExit"""
-        with self.assertRaises(SystemExit):
-            self.cmd.init_args([])
-            self.cmd.run()
+        with capture_sys_output():
+            with self.assertRaises(SystemExit):
+                self.cmd.init_args([])
+                self.cmd.run()
 
     def test_with_random_args(self):
         """User passes random args, should fail with SystemExit"""
-        with self.assertRaises(SystemExit):
-            self.cmd.init_args(["blaaaaaaa"])
-            self.cmd.run()
+        with capture_sys_output():
+            with self.assertRaises(SystemExit):
+                self.cmd.init_args(["blaaaaaaa"])
+                self.cmd.run()
 
     def test_arg_with_no_value(self):
         """User passed not boolean arg but no value"""
-        with self.assertRaises(SystemExit):
-            self.cmd.init_args(["--probes"])
-            self.cmd.run()
+        with capture_sys_output():
+            with self.assertRaises(SystemExit):
+                self.cmd.init_args(["--probes"])
+                self.cmd.run()
 
     def test_arg_with_wrong_type(self):
         """User passed arg with wrong type."""
-        with self.assertRaises(SystemExit):
-            self.cmd.init_args(["--probes", "blaaaaa"])
-            self.cmd.run()
+        with capture_sys_output():
+            with self.assertRaises(SystemExit):
+                self.cmd.init_args(["--probes", "blaaaaa"])
+                self.cmd.run()
 
     def test_arg_renderer_with_wrong_choice(self):
         """User passed arg renderer with unavailable type."""
-        with self.assertRaises(SystemExit):
-            self.cmd.init_args(["--renderer", "blaaaaa"])
-            self.cmd.run()
+        with capture_sys_output():
+            with self.assertRaises(SystemExit):
+                self.cmd.init_args(["--renderer", "blaaaaa"])
+                self.cmd.run()
 
     def test_arg_renderer_with_valid_choice(self):
         """User passed arg renderer with valid type."""
@@ -67,8 +74,9 @@ class TestReportCommand(unittest.TestCase):
             mock_get.return_value = False, {}
             for choice in Renderer.get_available():
                 with self.assertRaises(RipeAtlasToolsException):
-                    self.cmd.init_args(["--renderer", choice, "1"])
-                    self.cmd.run()
+                    cmd = Command()
+                    cmd.init_args(["--renderer", choice, "1"])
+                    cmd.run()
 
     def test_arg_aggregate_with_valid_choice(self):
         """User passed arg aggregate with valid type."""
@@ -78,26 +86,30 @@ class TestReportCommand(unittest.TestCase):
             mock_get.return_value = False, {}
             for choice in Command.AGGREGATORS.keys():
                 with self.assertRaises(RipeAtlasToolsException):
-                    self.cmd.init_args(["--aggregate-by", choice, "1"])
-                    self.cmd.run()
+                    cmd = Command()
+                    cmd.init_args(["--aggregate-by", choice, "1"])
+                    cmd.run()
 
     def test_arg_aggregate_with_wrong_choice(self):
         """User passed arg aggregate with unavailable type."""
-        with self.assertRaises(SystemExit):
-            self.cmd.init_args(["--aggregate-by", "blaaaaa"])
-            self.cmd.run()
+        with capture_sys_output():
+            with self.assertRaises(SystemExit):
+                self.cmd.init_args(["--aggregate-by", "blaaaaa"])
+                self.cmd.run()
 
     def test_arg_no_msm_id(self):
         """User passed no measurement id."""
-        with self.assertRaises(SystemExit):
-            self.cmd.init_args(["--aggregate-by", "country"])
-            self.cmd.run()
+        with capture_sys_output():
+            with self.assertRaises(SystemExit):
+                self.cmd.init_args(["--aggregate-by", "country"])
+                self.cmd.run()
 
     def test_arg_no_valid_msm_id(self):
         """User passed non valid type of measurement id."""
-        with self.assertRaises(SystemExit):
-            self.cmd.init_args(["blaaa"])
-            self.cmd.run()
+        with capture_sys_output():
+            with self.assertRaises(SystemExit):
+                self.cmd.init_args(["blaaa"])
+                self.cmd.run()
 
     def test_measurement_failure(self):
         """Testcase where given measurement id doesn't exist."""


### PR DESCRIPTION
This is a Big Heavy Refactoring of the `measure` command to make further expansion of it less scary.  Basically I've broken the `Command` class into smaller type-specific components which can (and probably should) be moved to separate files.  The crux of this is the introduction of a new `Factory` class, which is referenced from the `ripe-atlas` script.

If this gets approved, I'd like to move all of the `*MeasureCommand` classes into `ripe.atlas.tools.measure.<name>`, including `Command` which would move to `ripe.atlas.tools.measure.base`.  This would leave `Factory` as the only remaining class in `ripe.atlas.tools.commands.measure`.
 
Also, this PR closes #70.