### PR TITLE
cousteau is waiting list instead of string, this way no results are f…

### DIFF
--- a/ripe/atlas/tools/commands/report.py
+++ b/ripe/atlas/tools/commands/report.py
@@ -77,7 +77,7 @@ class Command(BaseCommand):
 
         kwargs = {"msm_id": self.arguments.measurement_id}
         if self.arguments.probes:
-            kwargs["probe_ids"] = ",".join([str(_) for _ in self.arguments.probes])
+            kwargs["probe_ids"] = self.arguments.probes
         if self.arguments.start_time:
             kwargs["start"] = self.arguments.start_time
         if self.arguments.stop_time:


### PR DESCRIPTION
…etched. needs a proper handling on cousteau side as well to be able to handle both dict/string.
@emileaben found out that he was not getting any results if probe_ids filters was used. Cousteau was splitting string and rejoining it to form new one, with wrong prb ids. This PR will fix it for now but I will change cousteau to be able to handle both dict/strings.