### PR TITLE
Smarter handling of --probes and --from-probes

### DIFF
--- a/ripe/atlas/tools/commands/measure/base.py
+++ b/ripe/atlas/tools/commands/measure/base.py
@@ -166,8 +166,10 @@ class Command(BaseCommand):
         self.parser.add_argument(
             "--probes",
             type=ArgumentType.integer_range(minimum=1),
-            default=conf["specification"]["source"]["requested"],
-            help="The number of probes you want to use"
+            default=None,
+            help="The number of probes you want to use.  Defaults to {},"
+                 "unless --from-probes is invoked, in which case the number of "
+                 "probes selected is used.".format(conf["specification"]["source"]["requested"])
         )
         self.parser.add_argument(
             "--include-tag",
@@ -187,6 +189,8 @@ class Command(BaseCommand):
         )
 
     def run(self):
+
+        self._account_for_selected_probes()
 
         if self.arguments.dry_run:
             return self.dry_run()
@@ -347,6 +351,26 @@ class Command(BaseCommand):
             if re.match(r"^\d+\.\d+\.\d+\.\d+$", self.arguments.target):
                 return 4
         return conf["specification"]["af"]
+
+    def _account_for_selected_probes(self):
+        """
+        If the user has used --from-probes, there's a little extra magic we
+        need to do.
+        """
+
+        # We can't use argparse's mutually_exclusive_group() method here because
+        # that library doesn't allow partial overlap.
+        if self.arguments.from_probes and self.arguments.probes:
+            raise RipeAtlasToolsException(
+                "Explicit probe selection (--from-probes) in incompatible with "
+                "a --probes argument."
+            )
+
+        configured = conf["specification"]["source"]["requested"]
+        if not self.arguments.probes:
+            self.arguments.probes = configured
+            if self.arguments.from_probes:
+                self.arguments.probes = len(self.arguments.from_probes)
 
     @staticmethod
     def _handle_api_error(response):

--- a/tests/commands/measure.py
+++ b/tests/commands/measure.py
@@ -796,3 +796,34 @@ class TestMeasureCommand(unittest.TestCase):
                                 option, extremes[0] + 1, extremes[1] - 1
                             )
                         )
+
+    @mock.patch(CONF, Configuration.DEFAULT)
+    def test_account_for_selected_probes(self):
+
+        spec = Configuration.DEFAULT["specification"]
+
+        cmd = PingMeasureCommand()
+        cmd.init_args(["ping", "--target", "ripe.net"])
+        cmd._account_for_selected_probes(),
+        self.assertEqual(cmd.arguments.probes, spec["source"]["requested"])
+
+        cmd = PingMeasureCommand()
+        cmd.init_args(["ping", "--target", "ripe.net", "--probes", "7"])
+        cmd._account_for_selected_probes(),
+        self.assertEqual(cmd.arguments.probes, 7)
+
+        cmd = PingMeasureCommand()
+        cmd.init_args(["ping", "--target", "ripe.net", "--from-probes", "1,2"])
+        cmd._account_for_selected_probes(),
+        self.assertEqual(cmd.arguments.probes, 2)
+
+        cmd = PingMeasureCommand()
+        cmd.init_args([
+            "ping",
+            "--target", "ripe.net",
+            "--from-probes", "1,2",
+            "--probes", "7"
+        ])
+        with capture_sys_output() as (stdout, stderr):
+            with self.assertRaises(RipeAtlasToolsException):
+                cmd._account_for_selected_probes(),


### PR DESCRIPTION
Does what it says on the tin.  I had to do a little hacking there due to how argparse handles mutually exclusive arguments (you can't have overlapping groups of such arguments), but the code is reasonably simple and easy-to-follow.

Closes #98.