### PR TITLE
New metadata "detail" commands

### DIFF
--- a/ripe/atlas/tools/commands/base.py
+++ b/ripe/atlas/tools/commands/base.py
@@ -162,6 +162,7 @@ class MetaDataMixin(object):
         print("{}  {}".format(
             colourise("{:25}".format(header), "bold"), value))
 
+
 class Factory(object):
 
     @classmethod

--- a/ripe/atlas/tools/commands/base.py
+++ b/ripe/atlas/tools/commands/base.py
@@ -1,6 +1,9 @@
 import argparse
 import re
+import six
 import sys
+
+from datetime import datetime
 
 from ..helpers.colours import colourise
 
@@ -133,6 +136,31 @@ class TabularFieldsMixin(object):
     def _get_filter_key_value_pair(self, k, v):
         return k.capitalize().replace("__", " "), v
 
+
+class MetaDataMixin(object):
+
+    @staticmethod
+    def _prettify_boolean(boolean):
+
+        checkmark = u"\u2714"
+        x = u"\u2718"
+        if six.PY2:
+            checkmark = checkmark.encode("utf-8")
+            x = x.encode("utf-8")
+
+        if boolean:
+            return colourise(checkmark, "green")
+        return colourise(x, "red")
+
+    @staticmethod
+    def _prettify_time(timestamp):
+        return "{} UTC".format(
+            datetime.fromtimestamp(timestamp).isoformat().replace("T", " "))
+
+    @staticmethod
+    def _render_line(header, value):
+        print("{}  {}".format(
+            colourise("{:25}".format(header), "bold"), value))
 
 class Factory(object):
 

--- a/ripe/atlas/tools/commands/measurement.py
+++ b/ripe/atlas/tools/commands/measurement.py
@@ -30,7 +30,7 @@ class Command(BaseCommand):
                 "That measurement does not appear to exist")
 
         self.render_basic(measurement)
-        self.render_ping(measurement)
+        getattr(self, "render_{}".format(measurement.type.lower()))(measurement)
 
     @classmethod
     def render_basic(cls, measurement):
@@ -38,7 +38,7 @@ class Command(BaseCommand):
         cls._render(measurement, (
             ("id", "ID"),
             ("id", "URL", lambda _: colourise(url_template.format(_), "cyan")),
-            ("type", "Type", lambda _: _["name"]),
+            ("type", "Type", lambda _: cls._prettify_type(_["name"])),
             ("status", "Status", lambda _: _["name"]),
             ("description", "Description"),
             ("af", "Address Family"),
@@ -65,13 +65,102 @@ class Command(BaseCommand):
     def render_ping(cls, measurement):
         cls._render(measurement, (
             ("packets", "Packets"),
-            ("size", "Size")
+            ("size", "Size"),
         ))
+
+    @classmethod
+    def render_traceroute(cls, measurement):
+        cls._render(measurement, (
+            ("packets", "Packets"),
+            ("protocol", "Protocol"),
+            ("dont_fragment", "Don't Fragment", cls._prettify_boolean),
+            ("paris", "Paris"),
+            ("first_hop", "First Hop"),
+            ("max_hops", "Maximum Hops"),
+            ("timeout", "Timeout"),
+            ("size", "Size"),
+            ("destination_option_size", "Destination Option Size"),
+            ("hop_by_hop_option_size", "Hop-by-hop Option Size"),
+            ("gap_limit", "Gap Limit"),
+        ))
+
+    @classmethod
+    def render_dns(cls, measurement):
+        cls._render(measurement, (
+            ("query", "Query", cls._prettify_query),
+            ("retry", "Retry Times"),
+            ("include_qbuf", "Include the Qbuf?", cls._prettify_boolean),
+            ("include_abuf", "Include the Abuf?", cls._prettify_boolean),
+            ("protocol", "Protocol"),
+            ("prepend_probe_id", "Prepend the Probe ID?"),
+            ("udp_payload_size", "UDP Payload Size"),
+            (
+                "use_probe_resolver",
+                "Use the Probe's Resolver?",
+                cls._prettify_boolean
+            ),
+            ("set_do_bit", "Set the DO Bit?", cls._prettify_boolean),
+            ("set_nsid_bit", "Set the NSID Bit?", cls._prettify_boolean),
+            ("set_rd_bit", "Set the RD Bit?", cls._prettify_boolean),
+            ("set_cd_bit", "Set the CD Bit?", cls._prettify_boolean),
+        ))
+
+    @classmethod
+    def render_sslcert(cls, measurement):
+        cls._render(measurement, (
+            ("port", "Port"),
+        ))
+
+    @classmethod
+    def render_http(cls, measurement):
+        cls._render(measurement, (
+            ("header_bytes", "Header Bytes"),
+            ("version", "Version"),
+            ("method", "Method"),
+            ("port", "Port"),
+            ("path", "Path"),
+            ("query_string", "Query String"),
+            ("user_agent", "User-Agent"),
+            ("max_bytes_read", "Body Bytes"),
+        ))
+        timing_verbosity = 0
+        if "extended_timing" in measurement.meta_data:
+            if measurement.meta_data["extended_timing"]:
+                timing_verbosity = 1
+                if "more_extended_timing" in measurement.meta_data:
+                    if measurement.meta_data["more_extended_timing"]:
+                        timing_verbosity = 2
+        cls._render_line("Timing Verbosity", timing_verbosity)
+
+    @classmethod
+    def render_ntp(cls, measurement):
+        cls._render(measurement, (
+            ("packets", "Packets"),
+            ("timeout", "Timeout"),
+        ))
+
+    @staticmethod
+    def _prettify_type(kind):
+        types = {
+            "ping": "Ping",
+            "traceroute": "Traceroute",
+            "dns": "DNS",
+            "sslcert": "SSL Certificate",
+            "http": "HTTP",
+            "ntp": "NTP"
+        }
+        if kind in types:
+            return colourise(colourise(types[kind], "bold"), "blue")
+        return colourise("Unknown", "red")
 
     @staticmethod
     def _prettify_time(timestamp):
         return "{} UTC".format(
             datetime.fromtimestamp(timestamp).isoformat().replace("T", " "))
+
+    @staticmethod
+    def _prettify_query(query):
+        return "{} {} {}".format(query["class"], query["type"], query["value"])
 
     @staticmethod
     def _prettify_boolean(boolean):
@@ -87,15 +176,21 @@ class Command(BaseCommand):
         return colourise(x, "red")
 
     @staticmethod
-    def _render(measurement, keys):
+    def _render_line(header, value):
+        print("{}  {}".format(
+            colourise("{:25}".format(header), "bold"), value))
+
+    @classmethod
+    def _render(cls, measurement, keys):
         for prop in keys:
+
+            value = None
             if prop[0] in measurement.meta_data:
                 value = measurement.meta_data[prop[0]]
-                if value is None:
-                    value = "N/A"
-                elif len(prop) == 3:
-                    value = prop[2](value)
-                print("{}  {}".format(
-                    colourise("{:20}".format(prop[1]), "bold"),
-                    value
-                ))
+
+            if value is None:
+                value = "-"
+            elif len(prop) == 3:
+                value = prop[2](value)
+
+            cls._render_line(prop[1], value)

--- a/ripe/atlas/tools/commands/measurement.py
+++ b/ripe/atlas/tools/commands/measurement.py
@@ -1,17 +1,14 @@
 from __future__ import print_function, absolute_import
 
-import six
-from datetime import datetime
-
 from ripe.atlas.cousteau import Measurement
 from ripe.atlas.cousteau.exceptions import APIResponseError
 
-from .base import Command as BaseCommand
+from .base import Command as BaseCommand, MetaDataMixin
 from ..exceptions import RipeAtlasToolsException
 from ..helpers.colours import colourise
 
 
-class Command(BaseCommand):
+class Command(MetaDataMixin, BaseCommand):
 
     NAME = "measurement"
     DESCRIPTION = (
@@ -156,31 +153,8 @@ class Command(BaseCommand):
         return colourise("Unknown", "red")
 
     @staticmethod
-    def _prettify_time(timestamp):
-        return "{} UTC".format(
-            datetime.fromtimestamp(timestamp).isoformat().replace("T", " "))
-
-    @staticmethod
     def _prettify_query(query):
         return "{} {} {}".format(query["class"], query["type"], query["value"])
-
-    @staticmethod
-    def _prettify_boolean(boolean):
-
-        checkmark = u"\u2714"
-        x = u"\u2718"
-        if six.PY2:
-            checkmark = checkmark.encode("utf-8")
-            x = x.encode("utf-8")
-
-        if boolean:
-            return colourise(checkmark, "green")
-        return colourise(x, "red")
-
-    @staticmethod
-    def _render_line(header, value):
-        print("{}  {}".format(
-            colourise("{:25}".format(header), "bold"), value))
 
     @classmethod
     def _render(cls, measurement, keys):

--- a/ripe/atlas/tools/commands/measurement.py
+++ b/ripe/atlas/tools/commands/measurement.py
@@ -1,0 +1,101 @@
+from __future__ import print_function, absolute_import
+
+import six
+from datetime import datetime
+
+from ripe.atlas.cousteau import Measurement
+from ripe.atlas.cousteau.exceptions import APIResponseError
+
+from .base import Command as BaseCommand
+from ..exceptions import RipeAtlasToolsException
+from ..helpers.colours import colourise
+
+
+class Command(BaseCommand):
+
+    NAME = "measurement"
+    DESCRIPTION = (
+        "Returns the meta data for one measurement"
+    )
+
+    def add_arguments(self):
+        self.parser.add_argument("id", type=int, help="The measurement id")
+
+    def run(self):
+
+        try:
+            measurement = Measurement(id=self.arguments.id)
+        except APIResponseError:
+            raise RipeAtlasToolsException(
+                "That measurement does not appear to exist")
+
+        self.render_basic(measurement)
+        self.render_ping(measurement)
+
+    @classmethod
+    def render_basic(cls, measurement):
+        url_template = "https://atlas.ripe.net/measurements/{}/"
+        cls._render(measurement, (
+            ("id", "ID"),
+            ("id", "URL", lambda _: colourise(url_template.format(_), "cyan")),
+            ("type", "Type", lambda _: _["name"]),
+            ("status", "Status", lambda _: _["name"]),
+            ("description", "Description"),
+            ("af", "Address Family"),
+            ("is_public", "Public?", cls._prettify_boolean),
+            ("is_oneoff", "One-off?", cls._prettify_boolean),
+            ("destination_name", "Destination Name"),
+            ("destination_address", "Destination Address"),
+            ("destination_asn", "Destination ASN"),
+            ("interval", "Interval"),
+            ("spread", "Spread"),
+            ("creation_time", "Created", cls._prettify_time),
+            ("start_time", "Started", cls._prettify_time),
+            ("stop_time", "Stopped", cls._prettify_time),
+            ("probes_requested", "Probes Requested"),
+            ("probes_scheduled", "Probes Scheduled"),
+            ("probes_currently_involved", "Probes Involved"),
+            ("participant_count", "Participant Count"),
+            ("is_all_scheduled", "Fully Scheduled?", cls._prettify_boolean),
+            ("resolved_ips", "Resolved IPs", lambda _: ", ".join(_)),
+            ("resolve_on_probe", "Resolve on the Probe", cls._prettify_boolean),
+        ))
+
+    @classmethod
+    def render_ping(cls, measurement):
+        cls._render(measurement, (
+            ("packets", "Packets"),
+            ("size", "Size")
+        ))
+
+    @staticmethod
+    def _prettify_time(timestamp):
+        return "{} UTC".format(
+            datetime.fromtimestamp(timestamp).isoformat().replace("T", " "))
+
+    @staticmethod
+    def _prettify_boolean(boolean):
+
+        checkmark = u"\u2714"
+        x = u"\u2718"
+        if six.PY2:
+            checkmark = checkmark.encode("utf-8")
+            x = x.encode("utf-8")
+
+        if boolean:
+            return colourise(checkmark, "green")
+        return colourise(x, "red")
+
+    @staticmethod
+    def _render(measurement, keys):
+        for prop in keys:
+            if prop[0] in measurement.meta_data:
+                value = measurement.meta_data[prop[0]]
+                if value is None:
+                    value = "N/A"
+                elif len(prop) == 3:
+                    value = prop[2](value)
+                print("{}  {}".format(
+                    colourise("{:20}".format(prop[1]), "bold"),
+                    value
+                ))

--- a/ripe/atlas/tools/commands/measurement.py
+++ b/ripe/atlas/tools/commands/measurement.py
@@ -113,6 +113,7 @@ class Command(BaseCommand):
 
     @classmethod
     def render_http(cls, measurement):
+
         cls._render(measurement, (
             ("header_bytes", "Header Bytes"),
             ("version", "Version"),
@@ -123,6 +124,7 @@ class Command(BaseCommand):
             ("user_agent", "User-Agent"),
             ("max_bytes_read", "Body Bytes"),
         ))
+
         timing_verbosity = 0
         if "extended_timing" in measurement.meta_data:
             if measurement.meta_data["extended_timing"]:

--- a/ripe/atlas/tools/commands/probe.py
+++ b/ripe/atlas/tools/commands/probe.py
@@ -10,7 +10,7 @@ from ..helpers.colours import colourise
 
 class Command(MetaDataMixin, BaseCommand):
 
-    NAME = "measurement"
+    NAME = "probe"
     DESCRIPTION = "Returns the meta data for one probe"
 
     def add_arguments(self):

--- a/ripe/atlas/tools/commands/probe.py
+++ b/ripe/atlas/tools/commands/probe.py
@@ -1,0 +1,66 @@
+from __future__ import print_function, absolute_import
+
+from ripe.atlas.cousteau import Probe
+from ripe.atlas.cousteau.exceptions import APIResponseError
+
+from .base import Command as BaseCommand, MetaDataMixin
+from ..exceptions import RipeAtlasToolsException
+from ..helpers.colours import colourise
+
+
+class Command(MetaDataMixin, BaseCommand):
+
+    NAME = "measurement"
+    DESCRIPTION = "Returns the meta data for one probe"
+
+    def add_arguments(self):
+        self.parser.add_argument("id", type=int, help="The probe id")
+
+    def run(self):
+
+        try:
+            probe = Probe(id=self.arguments.id)
+        except APIResponseError:
+            raise RipeAtlasToolsException(
+                "That probe does not appear to exist")
+
+        url_template = "https://atlas.ripe.net/probes/{}/"
+        keys = (
+            ("id", "ID"),
+            ("id", "URL", lambda _: colourise(url_template.format(_), "cyan")),
+            ("is_public", "Public?", self._prettify_boolean),
+            ("is_anchor", "Anchor?", self._prettify_boolean),
+            ("country_code", "Country"),
+            ("description", "Description"),
+            ("asn_v4", "ASN (IPv4)"),
+            ("asn_v6", "ASN (IPv6)"),
+            ("address_v4", "Address (IPv4)"),
+            ("address_v6", "Address (IPv6)"),
+            ("prefix_v4", "Prefix (IPv4)"),
+            ("prefix_v6", "Prefix (IPv6)"),
+            ("geometry", "Coordinates", self._prettify_coordinates),
+            # ("tags", "Tags"),
+            ("status", "Status"),
+        )
+        for key in keys:
+
+            value = getattr(probe, key[0])
+
+            if value is None:
+                value = "-"
+            elif len(key) == 3:
+                value = key[2](value)
+
+            self._render_line(key[1], value)
+
+        print(colourise("Tags", "bold"))
+        for tag in probe.tags:
+            print("  {}".format(tag["slug"]))
+
+    @staticmethod
+    def _prettify_coordinates(geometry):
+        if geometry and "coordinates" in geometry and geometry["coordinates"]:
+            return "{},{}".format(
+                geometry["coordinates"][1],
+                geometry["coordinates"][0]
+            )


### PR DESCRIPTION
After a discussion with @robert-kisteleki in #103, I figured that adding these wouldn't be too much effort and it wasn't, so I've added them here.

Basically it's a means for you to get all the details about a measurement or probe on the command line:

    $ ripe-atlas measurement 1000192
    ID                         1000192
    URL                        https://atlas.ripe.net/measurements/1000192/
    Type                       Ping
    Status                     Ongoing
    Description                -
    Address Family             4
    Public?                    ✔
    One-off?                   ✘
    Destination Name           hsi.cablecom.ch
    Destination Address        62.2.16.12
    Destination ASN            6830
    Interval                   360
    Spread                     -
    Created                    2012-01-31 15:19:49 UTC
    Started                    2012-01-31 15:19:49 UTC
    Stopped                    -
    Probes Requested           10
    Probes Scheduled           10
    Probes Involved            10
    Participant Count          10
    Fully Scheduled?           ✔
    Resolved IPs               62.2.16.12
    Resolve on the Probe       ✔
    Packets                    -
    Size                       -

or

    $ ripe-atlas probe 157
    ID                         157
    URL                        https://atlas.ripe.net/probes/157/
    Public?                    ✔
    Anchor?                    ✘
    Country                    NL
    Description                Amsterdam, NL
    ASN (IPv4)                 3265
    ASN (IPv6)                 3265
    Address (IPv4)             82.95.106.192
    Address (IPv6)             2001:981:5e40:1:220:4aff:fec8:20b9
    Prefix (IPv4)              82.92.0.0/14
    Prefix (IPv6)              2001:980::/30
    Coordinates                52.3805,4.6395
    Status                     Connected
    Tags
      dsl
      home
      nat
      system-v1
      system-resolves-a-correctly
      system-resolves-aaaa-correctly
      system-ipv4-works
      system-ipv6-works
      system-auto-geoip-city
      system-ipv4-capable
      system-ipv6-capable
      system-ipv4-rfc1918

Of note is the fact that I had to use `measurement.meta_data` as opposed to the more convenient object properties because everything I needed wasn't there.  Additionally, the API *doesn't return information about properties left undefined and as such are set to their default values*.  Jasper is working on this though, so when that's complete, the Magellan output will be more impressive :-)