### PR TITLE
Remove dateutil version and bump sagan

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,10 +31,10 @@ setup(
     maintainer="The RIPE Atlas team",
     maintainer_email="atlas@ripe.net",
     install_requires=[
-        "python-dateutil>=2.4.2",
+        "python-dateutil",
         "requests>=2.7.0",
         "ripe.atlas.cousteau>=1.0.4",
-        "ripe.atlas.sagan>=1.1.4",
+        "ripe.atlas.sagan>=1.1.6",
         "tzlocal",
         "pyyaml",
         "pyOpenSSL>=0.13",


### PR DESCRIPTION
It turns out that we don't need to be so picky about our dateutil version, so for the sake of the FreeBSD port, I've removed that bit here.  I've also bumped the Sagan dependency to keep things in sync.