### PR TITLE
Remove header from report

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Release History
 
 Bug Fixes
 ~~~~~~~~~
+- `#103`_: Removed header from the ``report`` command
 - `#105`_: Measurement report and stream broken on Python3.4
 
 1.1.0 (released 2015-11-12)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,10 +4,13 @@ Release History
 1.1.1
 -----
 
+# Output Changes
+~~~~~~~~~~~~~~~~
+- `#103`_: Removed header from the ``report`` command.
+
 Bug Fixes
 ~~~~~~~~~
-- `#103`_: Removed header from the ``report`` command
-- `#105`_: Measurement report and stream broken on Python3.4
+- `#105`_: Measurement report and stream broken on Python3.4.
 
 1.1.0 (released 2015-11-12)
 ---------------------------
@@ -26,10 +29,11 @@ Bug Fixes
 Changes
 ~~~~~~~
 - Better testing.
-- Additional documentation
+- Additional documentation.
 
 1.0.0 (released 2015-11-02)
 ---------------------------
 - Initial release.
 
+.. _#103: https://github.com/RIPE-NCC/ripe-atlas-tools/issues/103
 .. _#105: https://github.com/RIPE-NCC/ripe-atlas-tools/issues/105

--- a/ripe/atlas/tools/commands/report.py
+++ b/ripe/atlas/tools/commands/report.py
@@ -123,11 +123,7 @@ class Command(BaseCommand):
         if self.arguments.aggregate_by:
             results = aggregate(results, self.get_aggregators())
 
-        Rendering(
-            renderer=renderer,
-            header=self._get_header(measurement),
-            payload=results
-        ).render()
+        Rendering(renderer=renderer, payload=results).render()
 
     def get_aggregators(self):
         """Return aggregators list based on user input"""
@@ -145,17 +141,3 @@ class Command(BaseCommand):
             else:
                 aggregation_keys.append(aggregation_class(key=key))
         return aggregation_keys
-
-    def _get_header(self, measurement):
-        """
-        Most of the time you want a fancy header, but for the raw renderer,
-        we want nothing.
-        """
-
-        description = measurement.description or ""
-        if description:
-            description = "\n{}".format(description)
-
-        return ("\nRIPE Atlas Report for Measurement #{}\n"
-                "==================================================="
-                "{}\n".format(measurement.id, description))

--- a/tests/commands/report.py
+++ b/tests/commands/report.py
@@ -142,8 +142,6 @@ class TestReportCommand(unittest.TestCase):
     def test_valid_case_no_aggr(self):
         """Test case where we have result no aggregation."""
         expected_output = (
-            "\nRIPE Atlas Report for Measurement #1\n"
-            "===================================================\n\n"
             "20 bytes from probe #1216  109.190.83.40   to hsi.cablecom.ch (62.2.16.24): ttl=54 times:27.429,  25.672,  25.681, \n"
             "20 bytes from probe #165   194.85.27.7     to hsi.cablecom.ch (62.2.16.24): ttl=48 times:87.825,  87.611,  91.0,   \n"
             "20 bytes from probe #202   178.190.51.206  to hsi.cablecom.ch (62.2.16.24): ttl=52 times:40.024,  40.399,  39.29,  \n"
@@ -193,8 +191,6 @@ class TestReportCommand(unittest.TestCase):
     def test_valid_case_with_aggr(self):
         """Test case where we have result with aggregation."""
         expected_output = (
-            "\nRIPE Atlas Report for Measurement #1\n"
-            "===================================================\n\n"
             "RTT_MEDIAN: 40-50\n"
             " 20 bytes from probe #202   178.190.51.206  to hsi.cablecom.ch (62.2.16.24): ttl=52 times:40.024,  40.399,  39.29,  \n"
             " 20 bytes from probe #677   78.128.9.202    to hsi.cablecom.ch (62.2.16.24): ttl=54 times:40.715,  40.259,  40.317, \n"
@@ -250,8 +246,6 @@ class TestReportCommand(unittest.TestCase):
     def test_asns_filter(self):
         """Test case where user specified probe asns filters.."""
         expected_output = (
-            "\nRIPE Atlas Report for Measurement #1\n"
-            "===================================================\n\n"
             "20 bytes from probe #165   194.85.27.7     to hsi.cablecom.ch (62.2.16.24): ttl=48 times:87.825,  87.611,  91.0,   \n"
             "20 bytes from probe #945   92.111.237.94   to hsi.cablecom.ch (62.2.16.24): ttl=56 times:61.665,  23.833,  23.269, \n"
         )

--- a/tests/renderers/ssl_consistency.py
+++ b/tests/renderers/ssl_consistency.py
@@ -215,8 +215,6 @@ class TestSSLConsistency(unittest.TestCase):
         results = self.results[:2]
 
         expected_output = (
-            "\nRIPE Atlas Report for Measurement #1\n"
-            "===================================================\n\n"
             "Certificate:\n"
             "  Issuer: C=US, O=DigiCert Inc, CN=DigiCert High Assurance CA-3\n"
             "  Subject: C=US, O=The Tor Project, Inc., CN=*.torproject.org\n"


### PR DESCRIPTION
Closes #103

Removing the header because as @robert-kisteleki points out, it's largely useless.  If the user wants metadata about the measurement, she can invoke `ripe-atlas measurement <id>`.