### PR TITLE
Adding additional tox test 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27-pyflakes, py27-pep8, py27-coverage, py27, py34
+envlist=py27-pyflakes, py27-pep8, py27-coverage, py27, py34, py34-syntax
 
 [testenv]
 commands=python setup.py test []
@@ -21,3 +21,9 @@ commands=
      coverage run --source=ripe setup.py test
      coverage report -m
 deps=coverage
+
+[testenv:py34-syntax]
+whitelist_externals=bash
+commands=bash -c "find ripe/ tests/ -name "*.py" | xargs python -m py_compile"
+basepython=python3.4
+deps=


### PR DESCRIPTION
We had a py3 syntax error on dst_asn.py on previous versions that apparently wasn't caught with existing checks. That do the job now.