### PR TITLE
Added howto for plugins and updated the rendering framework for consistency

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,15 @@
 Release History
 ===============
 
+1.2.2 (released 2016-??-??)
+---------------------------
+
+New Features
+~~~~~~~~~~~~
+- Cleaner and more consistent implementation of the renderer plugable
+  architecture.
+
+
 1.2.1 (released 2015-12-15)
 ---------------------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,6 +26,7 @@ Contents
    quickstart
    installation
    use
+   plugins
    contributing
    packaging
    troubleshooting

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -1,0 +1,231 @@
+.. _plugins:
+
+How to Create Your Own Plugins
+==============================
+
+We built this toolkit for the community, and we knew going in that we couldn't
+possibly build every feature that every user could want, built this thing to be
+pluggable.  You can write your own renderer(s) and use them seamlessly within
+your own environment, and if you think that others might benefit from your work,
+you can share your renderer as easy as posting a file online.
+
+Ready?
+
+So you have an idea now.  You want to create a renderer called "awesomerenderer"
+and you want it to do some fancy things with traceroute measurement results.
+What do you have to do?
+
+
+.. _plugins-create:
+
+Create Your Renderer File
+-------------------------
+
+As we've already covered, Magellan will look for renderers in very specific
+places, so you need to put your file(s) there.  Additionally however, you have
+to make sure that you conform to Python norms, or stuff just won't work.  Here's
+the basic commands to get you started:
+
+.. code:: bash
+
+    $ mkdir -p ${HOME}/.config/ripe-atlas-tools/renderers
+    $ touch ${HOME}/.config/ripe-atlas-tools/renderers/__init__.py
+    $ touch ${HOME}/.config/ripe-atlas-tools/renderers/my_renderer.py
+
+The ``mkdir`` step there will create the renderers directory (if it doesn't
+exist already), and the ``touch`` commands will create the mandatory init file
+(for Python) and your renderer.  Note that you can use whatever name you like
+for your renderer, so long as it consists only of letters, numbers, and the
+underscore and that it starts with a letter.  Also, to be compliant with the
+rest of the project, it should be entirely lowercase.  For our purposes though,
+``my_renderer.py`` will suffice.
+
+
+.. _plugins-try-to-run:
+
+(Try to) Run It!
+----------------
+
+If you run this right now:
+
+.. code:: bash
+
+    $ ripe-atlas report --help
+
+You should see ``my_renderer`` int he list of options for ``--renderer``.
+Pretty cool eh?  However, if you try to run that, this'll happen:
+
+.. code:: bash
+
+    $ ripe-atlas report 1000192 --renderer my_renderer
+    The renderer you selected, "my_renderer" could not be found.
+
+Which kind of makes sense really.  You've created a file called ``my_renderer``,
+but it's totally empty.  Magellan found the file alright, but when it tried to
+import ``Renderer`` from it, everything exploded.
+
+
+.. _plugins-write:
+
+Actually Write a Renderer
+-------------------------
+
+So now you know that we can see your renderer file, but you need to know what
+kind of code to put in there.  Don't worry, we've got you covered:
+
+
+.. _plugins-write-anatomy:
+
+Anatomy of a Renderer
+~~~~~~~~~~~~~~~~~~~~~
+
+A "renderer" is simply a file located in a special place that contains some
+Python code defining a class called ``Renderer`` that subclasses
+``ripe.atlas.tools.renderers.base.BaseRenderer``.
+
+Your class need only define one method: ``on_result()``, which is called every
+time a new result comes down the pipe.  Let's look at a really simple example:
+
+.. code:: python
+
+    from ripe.atlas.tools.renderers.base import Renderer as BaseRenderer
+
+
+    class Renderer(BaseRenderer):
+
+        # This renderer is capable of handling ping results only.
+        RENDERS = [BaseRenderer.TYPE_PING]
+
+        def on_result(self, result):
+            """
+            on_result() only gets one argument, a result object, which is
+            actually an instance of a RIPE Atlas result parsed with Sagan:
+              https://ripe-atlas-sagan.readthedocs.org/
+            """
+
+            return "Packets received: {}".format(result.packets_received)
+
+As you can see, this renderer isn't very useful, but we're providing it here to
+give you a rough idea of what you get to play with when defining your own
+renderer.
+
+In the case of our PingPacketRenderer, we're doing the simplest of tasks: we're
+returning the number of packets in each result.  The job of ``on_result()`` is
+to take a Sagan result object as input and return a string.  **It should not
+print anything to standard out**, rather it should simply return a string that
+will get printed to standard out by the surrounding framework.
+
+
+.. _plugins-write-anatomy-additional:
+
+Additional Options
+::::::::::::::::::
+
+It's likely that you will only ever need to work with ``on_result()``, but in
+the event that you'd like to get more complicated, there are options:
+``header()``, ``additional()``, and ``footer()``.  Note however that these other
+methods are currently only available to the ``report`` command.  Streaming only
+makes use of ``on_result()``.
+
+
+.. _plugins-write-anatomy-additional-header:
+
+header()
+........
+
+By default this returns ``None``, but if you define this method and have it
+return a string, that string will be printed to standard out before any results
+are captured.
+
+
+.. _plugins-write-anatomy-additional-additional:
+
+additional()
+............
+
+Typically used for summary logic, this is executed after the last result is
+rendered.  A common pattern is to override ``__init__()`` to set some collector
+properties, update them via ``on_result()``, and then print out said properties
+in a summary via this method.  For an example, let's update our ``Renderer``
+class:
+
+.. code:: python
+
+    from ripe.atlas.tools.renderers.base import Renderer as BaseRenderer
+
+
+    class Renderer(BaseRenderer):
+
+        RENDERS = [BaseRenderer.TYPE_PING]
+
+        def __init__(self, *args, **kwargs):
+            self.packet_total = 0
+            BaseRenderer.__init__(self, *args, **kwargs)
+
+        def on_result(self, result):
+            self.packet_total += result.packets_received
+            return "Packets received: {}\n".format(result.packets_received)
+
+        def additional(self, results):
+            return "\nTotal packets received: {}\n".format(self.packet_total)
+
+Note that the passed-in value of ``results`` is the list of Sagan Result objects
+that were previously looped over for on_result().  You can do some interesting
+things with that.
+
+
+.. _plugins-write-anatomy-additional-footer:
+
+footer()
+........
+
+Much the same as the ``header()``, this should return a string, but unlike the
+header, the output of this method is rendered after everything else.
+
+
+.. _plugins-run:
+
+Run It!
+-------
+
+Now that you've written your renderer and the file is stored where it's supposed
+to be, it should be ready to go:
+
+.. code:: bash
+
+    $ ripe-atlas report --help
+
+You should see ``my_renderer`` in the list of options for ``--renderer`` just as
+before, but now when you actually try to execute it...
+
+.. code:: bash
+
+    $ ripe-atlas report 1000192 --renderer my_renderer
+    Packets received: 3
+    Packets received: 3
+    Packets received: 3
+    Packets received: 3
+    Packets received: 3
+    Packets received: 3
+
+    Total packets received: 18
+
+It's not very interesting, but it's a start!
+
+
+.. _plugins-contributing:
+
+Contributing
+------------
+
+We love it when people write stuff that talks to our stuff.  If you think your
+stuff is useful, it'd be awesome if you could do any of these:
+
+* Post to the [ripe-atlas mailing list](https://www.ripe.net/mailman/listinfo/ripe-atlas)
+  about it.  You can also solicit feedback from the RIPE Atlas developers or the
+  wider community on this list.
+* Write a blog post about your plugin, what makes it useful, etc.
+* Tweet about it.  Feel free to mention [@RIPE_Atlas](https://twitter.com/ripe_atlas)
+  and we might even retweet it.
+* Create a [pull request](https://github.com/RIPE-NCC/ripe-atlas-tools/pulls)
+  for this project to get your plugin added to core.

--- a/docs/plugins.rst
+++ b/docs/plugins.rst
@@ -4,10 +4,11 @@ How to Create Your Own Plugins
 ==============================
 
 We built this toolkit for the community, and we knew going in that we couldn't
-possibly build every feature that every user could want, built this thing to be
-pluggable.  You can write your own renderer(s) and use them seamlessly within
-your own environment, and if you think that others might benefit from your work,
-you can share your renderer as easy as posting a file online.
+possibly build every feature that every user could want, so we built this
+thing to be pluggable.  You can write your own renderer(s) and use them
+seamlessly within your own environment, and if you think that others might
+benefit from your work, you can share your renderer as easy as posting a file
+online.
 
 Ready?
 
@@ -133,9 +134,8 @@ makes use of ``on_result()``.
 header()
 ........
 
-By default this returns ``None``, but if you define this method and have it
-return a string, that string will be printed to standard out before any results
-are captured.
+The value returned from this method is printed to standard out before any
+results are captured.  By default it returns an empty string.
 
 
 .. _plugins-write-anatomy-additional-additional:
@@ -179,8 +179,8 @@ things with that.
 footer()
 ........
 
-Much the same as the ``header()``, this should return a string, but unlike the
-header, the output of this method is rendered after everything else.
+Much the same as ``header()``, this should return a string, but unlike
+``header()``, the output of this method is rendered after everything else.
 
 
 .. _plugins-run:

--- a/ripe/atlas/tools/helpers/rendering.py
+++ b/ripe/atlas/tools/helpers/rendering.py
@@ -15,9 +15,11 @@
 
 from __future__ import print_function
 
-from ripe.atlas.sagan import Result, ResultParseError
+from ripe.atlas.sagan import Result as SaganResult
+from ripe.atlas.sagan import ResultParseError
 
 from ..probes import Probe
+from ..renderers.base import Result as MagellanResult
 
 
 class SaganSet(object):
@@ -46,10 +48,10 @@ class SaganSet(object):
                 break
 
             try:
-                sagan = Result.get(
+                sagan = SaganResult.get(
                     line,
-                    on_error=Result.ACTION_IGNORE,
-                    on_warning=Result.ACTION_IGNORE
+                    on_error=SaganResult.ACTION_IGNORE,
+                    on_warning=SaganResult.ACTION_IGNORE
                 )
                 if not self._probes or sagan.probe_id in self._probes:
                     sagans.append(sagan)
@@ -89,18 +91,24 @@ class Rendering(object):
         self.payload = payload
 
     def render(self):
+
         if self.renderer.SHOW_DEFAULT_HEADER:
             print(self.header, end="")
-        self.renderer.header()
+
+        print(self.renderer.header(), end="")
+
         self._smart_render(self.payload)
-        self.renderer.additional(self.payload)
-        self.renderer.footer()
+
+        print(self.renderer.additional(self.payload), end="")
+
+        print(self.renderer.footer(), end="")
+
         if self.renderer.SHOW_DEFAULT_FOOTER:
             print(self.footer, end="")
 
     def _get_rendered_results(self, data):
         for sagan in data:
-            yield self.renderer.on_result(sagan)
+            yield MagellanResult(self.renderer.on_result(sagan), sagan.probe_id)
 
     def _smart_render(self, data, indent=""):
         """

--- a/ripe/atlas/tools/renderers/aggregate_ping.py
+++ b/ripe/atlas/tools/renderers/aggregate_ping.py
@@ -40,12 +40,12 @@ class Renderer(BaseRenderer):
         }
 
     def header(self):
-        print("Collecting results...\n")
+        return "Collecting results...\n"
 
     def additional(self, results):
         self.collect_stats(results)
         self.packet_loss = self.calculate_loss()
-        print(self.render(
+        return self.render(
             "reports/aggregate_ping.txt",
             target=sanitise(self.target),
             sent=self.sent_packets,
@@ -55,7 +55,7 @@ class Renderer(BaseRenderer):
             median=self.median(),
             mean=self.mean(),
             max=max(self.rtts_max)
-        ))
+        )
 
     def collect_stats(self, results):
         """

--- a/ripe/atlas/tools/renderers/base.py
+++ b/ripe/atlas/tools/renderers/base.py
@@ -35,6 +35,9 @@ class Renderer(object):
     SHOW_DEFAULT_HEADER = True
     SHOW_DEFAULT_FOOTER = True
 
+    def __init__(self, *args, **kwargs):
+        pass
+
     @staticmethod
     def get_available():
         """
@@ -122,26 +125,23 @@ class Renderer(object):
             "Renderer"
         )
 
-    @staticmethod
-    def header(*args, **kwargs):
+    def header(self):
         """
         Override this to add an additional header.
         """
-        pass
+        return ""
 
-    @staticmethod
-    def additional(*args, **kwargs):
+    def additional(self, results):
         """
         Override this for summary logic.
         """
-        pass
+        return ""
 
-    @staticmethod
-    def footer(*args, **kwargs):
+    def footer(self):
         """
         Override this to add an additional footer.
         """
-        pass
+        return ""
 
     @staticmethod
     def _test_renderer_accepts_kind(renderer, kind):

--- a/ripe/atlas/tools/renderers/dst_asn.py
+++ b/ripe/atlas/tools/renderers/dst_asn.py
@@ -27,7 +27,10 @@ class Renderer(BaseRenderer):
     SHOW_DEFAULT_HEADER = False
     SHOW_DEFAULT_FOOTER = False
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+
+        BaseRenderer.__init__(self, *args, **kwargs)
+
         # Keys are timestamps, data struct captures ASN membership
         self.asns = Counter()
         self.asn2name = {}
@@ -46,10 +49,15 @@ class Renderer(BaseRenderer):
         return ""
 
     def additional(self, results):
+
         total = sum(self.asns.values())
+
+        r = ""
         for asn, count in self.asns.most_common():
-            print("AS%s %.2f%% (%s)" % (
+            r += "AS%s %.2f%% (%s)" % (
                 asn,
                 100.0 * count / total,
                 self.asn2name[asn]
-            ))
+            )
+
+        return r

--- a/ripe/atlas/tools/renderers/http.py
+++ b/ripe/atlas/tools/renderers/http.py
@@ -16,7 +16,6 @@
 from ..helpers.colours import colourise
 
 from .base import Renderer as BaseRenderer
-from .base import Result
 
 
 class Renderer(BaseRenderer):
@@ -57,7 +56,7 @@ class Renderer(BaseRenderer):
                 response.code
             )
 
-        return Result(r + "\n", result.probe_id)
+        return r + "\n"
 
     def _colourise_by_status(self, output, status):
         try:

--- a/ripe/atlas/tools/renderers/ntp.py
+++ b/ripe/atlas/tools/renderers/ntp.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from .base import Renderer as BaseRenderer
-from .base import Result
 
 
 class Renderer(BaseRenderer):
@@ -22,4 +21,4 @@ class Renderer(BaseRenderer):
     RENDERS = [BaseRenderer.TYPE_NTP]
 
     def on_result(self, result, probes=None):
-        return Result("Not ready yet\n", result.probe_id)
+        return "Not ready yet\n"

--- a/ripe/atlas/tools/renderers/ping.py
+++ b/ripe/atlas/tools/renderers/ping.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from .base import Renderer as BaseRenderer
-from .base import Result
 
 
 class Renderer(BaseRenderer):
@@ -35,7 +34,7 @@ class Renderer(BaseRenderer):
             origin = packets[0].source_address
 
         line = "{} bytes from probe #{:<5} {:15} to {} ({}): ttl={} times:{}\n"
-        return Result(line.format(
+        return line.format(
             result.packet_size,
             result.probe_id,
             origin,
@@ -43,4 +42,4 @@ class Renderer(BaseRenderer):
             result.destination_address,
             packets[0].ttl,
             " ".join(["{:8}".format(str(_.rtt) + ",") for _ in packets])
-        ), result.probe_id)
+        )

--- a/ripe/atlas/tools/renderers/ssl_consistency.py
+++ b/ripe/atlas/tools/renderers/ssl_consistency.py
@@ -20,9 +20,11 @@ THRESHOLD = 80  # %
 
 
 class Renderer(BaseRenderer):
+
     RENDERS = [BaseRenderer.TYPE_SSLCERT]
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        BaseRenderer.__init__(self, *args, **kwargs)
         self.uniqcerts = {}
         self.blob_list = []
 
@@ -38,7 +40,7 @@ class Renderer(BaseRenderer):
             if self.uniqcerts[cert_id]["cnt"] < most_seen_cert * THRESHOLD / 100:
                 self.blob_list.extend(self.render_below_threshold(cert_id))
 
-        print("\n".join(self.blob_list))
+        return "\n".join(self.blob_list)
 
     def gather_unique_certs(self, results):
         for result in results:

--- a/ripe/atlas/tools/renderers/templates/reports/aggregate_ping.txt
+++ b/ripe/atlas/tools/renderers/templates/reports/aggregate_ping.txt
@@ -1,3 +1,4 @@
 -- {target} ping statistics ---
 {sent} packets transmitted, {received} received, {packet_loss}% loss
 rtt min/med/avg/max = {min}/{median}/{mean}/{max} ms
+

--- a/ripe/atlas/tools/renderers/traceroute.py
+++ b/ripe/atlas/tools/renderers/traceroute.py
@@ -14,7 +14,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from .base import Renderer as BaseRenderer
-from .base import Result
 
 from ..helpers.colours import colourise
 from ..helpers.sanitisers import sanitise
@@ -50,10 +49,7 @@ class Renderer(BaseRenderer):
                 "  ".join(rtts)
             )
 
-        return Result(
-            "\n{}\n\n{}".format(
-                colourise("Probe #{}".format(result.probe_id), "bold"),
-                r
-            ),
-            result.probe_id
+        return "\n{}\n\n{}".format(
+            colourise("Probe #{}".format(result.probe_id), "bold"),
+            r
         )

--- a/ripe/atlas/tools/renderers/traceroute_aspath.py
+++ b/ripe/atlas/tools/renderers/traceroute_aspath.py
@@ -15,14 +15,14 @@
 
 from ..ipdetails import IP
 from .base import Renderer as BaseRenderer
-from .base import Result
 
 
 class Renderer(BaseRenderer):
 
     RENDERS = [BaseRenderer.TYPE_TRACEROUTE]
 
-    def __init__(self):
+    def __init__(self, *args, **kwargs):
+        BaseRenderer.__init__(self, *args, **kwargs)
         self.paths = {}
 
         # Number of different ASs starting from the end of the traceroute path.
@@ -73,14 +73,12 @@ class Renderer(BaseRenderer):
         if result.destination_ip_responded:
             self.paths[as_path]['responded'] += 1
 
-        return Result(
-            "Probe #{:<5}: {}, {}completed\n".format(
-                result.probe_id, as_path,
-                "NOT " if not result.destination_ip_responded else ""
-            ), result.probe_id
+        return "Probe #{:<5}: {}, {}completed\n".format(
+            result.probe_id, as_path,
+            "NOT " if not result.destination_ip_responded else ""
         )
 
-    def on_finish(self):
+    def additional(self, results):
         s = "\nNumber of probes for each AS path:\n\n"
 
         for as_path in self.paths:

--- a/ripe/atlas/tools/version.py
+++ b/ripe/atlas/tools/version.py
@@ -13,4 +13,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"

--- a/tests/renderers/aggregate_ping.py
+++ b/tests/renderers/aggregate_ping.py
@@ -48,9 +48,7 @@ class TestAggregatePing(unittest.TestCase):
             "rtt min/med/avg/max = 36.921608/42.406/82.693/218.077484 ms\n\n"
         )
 
-        with capture_sys_output() as (stdout, stderr):
-            Renderer().additional(self.sagans)
-            self.assertEquals(stdout.getvalue(), expected_output)
+        self.assertEquals(Renderer().additional(self.sagans), expected_output)
 
     def test_collect_stats(self):
         """Tests collect stats function."""

--- a/tests/renderers/http.py
+++ b/tests/renderers/http.py
@@ -34,7 +34,6 @@ class TestHttpRenderer(unittest.TestCase):
             'GET http://at-vie-as1120.anchors.atlas.ripe.net:80/4096 217.13.64.36 193.171.255.2 200 45.953289 1.1 131 1668618\n\n'
         )
         self.assertEqual(Renderer().on_result(self.basic), expected)
-        self.assertEqual(Renderer().on_result(self.basic).probe_id, 1)
 
     def test_multiple(self):
         expected = (
@@ -45,4 +44,3 @@ class TestHttpRenderer(unittest.TestCase):
             'GET http://at-vie-as1120.anchors.atlas.ripe.net:80/4096 217.13.64.36 193.171.255.2 200 45.953289 1.1 131 1668618\n\n'
         )
         self.assertEqual(Renderer().on_result(self.multiple), expected)
-        self.assertEqual(Renderer().on_result(self.basic).probe_id, 1)

--- a/tests/renderers/ping.py
+++ b/tests/renderers/ping.py
@@ -31,7 +31,6 @@ class TestPingRenderer(unittest.TestCase):
             Renderer().on_result(self.basic),
             "20 bytes from probe #1     1.2.3.4         to my.name.ca (3.4.5.6): ttl=20 times:10.001,  10.002,  10.003, \n"
         )
-        self.assertEqual(Renderer().on_result(self.basic).probe_id, 1)
 
     def test_no_packets(self):
         self.assertEqual(

--- a/tests/renderers/ssl_consistency.py
+++ b/tests/renderers/ssl_consistency.py
@@ -124,15 +124,13 @@ class TestSSLConsistency(unittest.TestCase):
             "    ID: 2844, country code: GR, ASN (v4/v6): 3333/4444\n"
         )
 
-        with capture_sys_output() as (stdout, stderr):
-            path = 'ripe.atlas.tools.helpers.rendering.Probe.get_many'
-            with mock.patch(path) as mock_get_many:
-                mock_get_many.return_value = self.probes.values()
-                sagans = SaganSet(self.results)
-                Renderer().additional(sagans)
-                expected_set = set(expected_output.split("\n"))
-                returned_set = set(stdout.getvalue().split("\n"))
-                self.assertEquals(returned_set, expected_set)
+        path = 'ripe.atlas.tools.helpers.rendering.Probe.get_many'
+        with mock.patch(path) as mock_get_many:
+            mock_get_many.return_value = self.probes.values()
+            self.assertEquals(
+                set(Renderer().additional(SaganSet(self.results)).split("\n")),
+                set(expected_output.split("\n"))
+            )
 
     def test_gather_unique_certs(self):
         """Test gathering of the unique certs in sagans set"""


### PR DESCRIPTION
I started just writing the doc, but when I tried to follow along in the plugin creation process, I ran into a lot of inconsistencies in how we implement the renderer logic:

* `header()`, `additional()` and `footer()` weren't printed, but rather relied on the user to execute a print within them, while on_result() returned data to be printed.
* Each renderer's `on_result()` method was expected to return a `Result` object, which was just the string + the probe id.  This was just as easily accomplished in the `Rendering` class, so I moved this logic up into that, leaving the on_result() to just return a plain old string.
* I defined \__init__() as an empty method that expects `*args` and `**kwargs` and changed both the documentation and all of the existing renderers to invoke the parent.  This allows us to change things in the future without breaking other people's plugins.