### PR TITLE
DNS and Traceroute measurements can accept parameters in lower case 

### DIFF
--- a/ripe/atlas/tools/commands/measure/dns.py
+++ b/ripe/atlas/tools/commands/measure/dns.py
@@ -26,6 +26,15 @@ from .base import Command
 
 class DnsMeasureCommand(Command):
 
+    def _upper_str(self, s):
+        """
+        Private method to validate specific command line arguments that
+        should be provided in upper or lower case
+        :param s: string
+        :return: string in upper case
+        """
+        return s.upper()
+
     def add_arguments(self):
 
         Command.add_arguments(self)
@@ -33,14 +42,14 @@ class DnsMeasureCommand(Command):
         specific = self.parser.add_argument_group("DNS-specific Options")
         specific.add_argument(
             "--protocol",
-            type=str,
+            type=self._upper_str,
             choices=("UDP", "TCP"),
             default=conf["specification"]["types"]["dns"]["protocol"],
             help="The protocol used."
         )
         specific.add_argument(
             "--query-class",
-            type=str,
+            type=self._upper_str,
             choices=("IN", "CHAOS"),
             default=conf["specification"]["types"]["dns"]["query-class"],
             help='The query class.  The default is "{}"'.format(
@@ -49,7 +58,7 @@ class DnsMeasureCommand(Command):
         )
         specific.add_argument(
             "--query-type",
-            type=str,
+            type=self._upper_str,
             choices=list(Message.ANSWER_CLASSES.keys()) + ["ANY"],  # The only ones we can parse
             default=conf["specification"]["types"]["dns"]["query-type"],
             help='The query type.  The default is "{}"'.format(

--- a/ripe/atlas/tools/commands/measure/traceroute.py
+++ b/ripe/atlas/tools/commands/measure/traceroute.py
@@ -23,6 +23,16 @@ from .base import Command
 
 class TracerouteMeasureCommand(Command):
 
+    def _upper_str(self, s):
+        """
+        Private method to validate specific command line arguments that
+        should be provided in upper or lower case
+        :param s: string
+        :return: string in upper case
+        """
+        return s.upper()
+
+
     def add_arguments(self):
 
         Command.add_arguments(self)
@@ -45,7 +55,7 @@ class TracerouteMeasureCommand(Command):
         )
         specific.add_argument(
             "--protocol",
-            type=str,
+            type=self._upper_str,
             choices=("ICMP", "UDP", "TCP"),
             default=spec["protocol"],
             help="The protocol used."

--- a/ripe/atlas/tools/commands/measure/traceroute.py
+++ b/ripe/atlas/tools/commands/measure/traceroute.py
@@ -32,7 +32,6 @@ class TracerouteMeasureCommand(Command):
         """
         return s.upper()
 
-
     def add_arguments(self):
 
         Command.add_arguments(self)

--- a/tests/commands/measure.py
+++ b/tests/commands/measure.py
@@ -266,6 +266,31 @@ class TestMeasureCommand(unittest.TestCase):
             }
         )
 
+        """Tests for the protocol provided in lower case"""
+        cmd = TracerouteMeasureCommand()
+        cmd.init_args([
+            "traceroute", "--target", "ripe.net", "--protocol", "icmp"
+        ])
+        self.assertEqual(
+            cmd._get_measurement_kwargs(),
+            {
+                "af": Configuration.DEFAULT["specification"]["af"],
+                "description": "Traceroute measurement to ripe.net",
+                "target": "ripe.net",
+                "packets": spec["packets"],
+                "size": spec["size"],
+                "destination_option_size": spec["destination-option-size"],
+                "hop_by_hop_option_size": spec["hop-by-hop-option-size"],
+                "dont_fragment": spec["dont-fragment"],
+                "first_hop": spec["first-hop"],
+                "max_hops": spec["max-hops"],
+                "paris": spec["paris"],
+                "port": spec["port"],
+                "protocol": "ICMP",
+                "timeout": spec["timeout"]
+            }
+        )
+
     @mock.patch(CONF, Configuration.DEFAULT)
     def test_get_measurement_kwargs_dns(self):
 
@@ -328,6 +353,78 @@ class TestMeasureCommand(unittest.TestCase):
                 "retry": 2,
                 "udp_payload_size": 5,
                 "use_probe_resolver": False
+            }
+        )
+
+        """Testing for protocol argument in lower case"""
+        cmd = DnsMeasureCommand()
+        cmd.init_args([
+            "dns", "--query-argument", "ripe.net", "--protocol", "tcp"
+        ])
+        self.assertEqual(
+            cmd._get_measurement_kwargs(),
+            {
+                "af": Configuration.DEFAULT["specification"]["af"],
+                "description": "DNS measurement for ripe.net",
+                "query_class": spec["query-class"],
+                "query_type": spec["query-type"],
+                "query_argument": "ripe.net",
+                "set_cd_bit": spec["set-cd-bit"],
+                "set_do_bit": spec["set-do-bit"],
+                "set_rd_bit": spec["set-rd-bit"],
+                "set_nsid_bit": spec["set-nsid-bit"],
+                "protocol": "TCP",
+                "retry": spec["retry"],
+                "udp_payload_size": spec["udp-payload-size"],
+                "use_probe_resolver": True,
+            }
+        )
+
+        """Testing for query class in lower case"""
+        cmd = DnsMeasureCommand()
+        cmd.init_args([
+            "dns", "--query-argument", "ripe.net", "--query-class", "in"
+        ])
+        self.assertEqual(
+            cmd._get_measurement_kwargs(),
+            {
+                "af": Configuration.DEFAULT["specification"]["af"],
+                "description": "DNS measurement for ripe.net",
+                "query_class": "IN",
+                "query_type": spec["query-type"],
+                "query_argument": "ripe.net",
+                "set_cd_bit": spec["set-cd-bit"],
+                "set_do_bit": spec["set-do-bit"],
+                "set_rd_bit": spec["set-rd-bit"],
+                "set_nsid_bit": spec["set-nsid-bit"],
+                "protocol": spec["protocol"],
+                "retry": spec["retry"],
+                "udp_payload_size": spec["udp-payload-size"],
+                "use_probe_resolver": True,
+            }
+        )
+
+        """Testing for query type in lower case"""
+        cmd = DnsMeasureCommand()
+        cmd.init_args([
+            "dns", "--query-argument", "ripe.net", "--query-type", "txt"
+        ])
+        self.assertEqual(
+            cmd._get_measurement_kwargs(),
+            {
+                "af": Configuration.DEFAULT["specification"]["af"],
+                "description": "DNS measurement for ripe.net",
+                "query_class": spec["query-class"],
+                "query_type": "TXT",
+                "query_argument": "ripe.net",
+                "set_cd_bit": spec["set-cd-bit"],
+                "set_do_bit": spec["set-do-bit"],
+                "set_rd_bit": spec["set-rd-bit"],
+                "set_nsid_bit": spec["set-nsid-bit"],
+                "protocol": spec["protocol"],
+                "retry": spec["retry"],
+                "udp_payload_size": spec["udp-payload-size"],
+                "use_probe_resolver": True,
             }
         )
 
@@ -708,7 +805,7 @@ class TestMeasureCommand(unittest.TestCase):
             self.assertEqual(
                 stderr.getvalue().split("\n")[-2],
                 "ripe-atlas measure: error: argument --protocol: invalid "
-                "choice: 'invalid' (choose from 'ICMP', 'UDP', 'TCP')"
+                "choice: 'INVALID' (choose from 'ICMP', 'UDP', 'TCP')"
             )
 
         with capture_sys_output() as (stdout, stderr):
@@ -717,7 +814,7 @@ class TestMeasureCommand(unittest.TestCase):
             self.assertEqual(
                 stderr.getvalue().split("\n")[-2],
                 "ripe-atlas measure: error: argument --protocol: invalid "
-                "choice: 'invalid' (choose from 'UDP', 'TCP')"
+                "choice: 'INVALID' (choose from 'UDP', 'TCP')"
             )
 
         with capture_sys_output() as (stdout, stderr):


### PR DESCRIPTION
While testing the command line tools, found a little bit pedantic to reject parameters just because they are in lower case. This applies for DNS measurements with 'protocol', 'query-class' and 'query-type', as well as Traceroute measurements with 'protocol'.

Made the tweaks to accept lower, upper or mixed case, and corresponding test cases. All tests pass.