### PR TITLE
Fixes needed for Windows support

### DIFF
--- a/ripe/atlas/tools/cache.py
+++ b/ripe/atlas/tools/cache.py
@@ -19,7 +19,10 @@ except ImportError:
     import pickle
 
 import datetime
-import dbm
+try:
+    import anydbm as dbm  # anydbm py2.7 will use the best available dbm
+except ImportError:
+    import dbm  # ... and on Python3 dbm does the same
 import functools
 import os
 import sys

--- a/ripe/atlas/tools/commands/base.py
+++ b/ripe/atlas/tools/commands/base.py
@@ -52,9 +52,10 @@ class Command(object):
     def get_available_commands():
         """
         Get a list of commands that we can execute.  By default, we have a
-        fixed that we make available in this directory, but the user can create
-        her own plugins and store them at ~/.config/ripe-atlas-tools/commands/.
-        If we find any files there, we add them to the list here.
+        fixed list that we make available in this directory, but the user can
+        create her own plugins and store them at
+        ~/.config/ripe-atlas-tools/commands/.  If we find any files there, we
+        add them to the list here.
         """
 
         paths = [os.path.dirname(__file__)]

--- a/ripe/atlas/tools/commands/base.py
+++ b/ripe/atlas/tools/commands/base.py
@@ -13,12 +13,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from datetime import datetime
+import argparse
 import os
+import pkgutil
 import re
 import six
 import sys
-import argparse
-from datetime import datetime
 
 from ..helpers.colours import colourise
 from ..version import __version__
@@ -46,6 +47,28 @@ class Command(object):
             prog="ripe-atlas {}".format(self.NAME)
         )
         self.user_agent = self._get_user_agent()
+
+    @staticmethod
+    def get_available_commands():
+        """
+        Get a list of commands that we can execute.  By default, we have a
+        fixed that we make available in this directory, but the user can create
+        her own plugins and store them at ~/.config/ripe-atlas-tools/commands/.
+        If we find any files there, we add them to the list here.
+        """
+
+        paths = [os.path.dirname(__file__)]
+
+        paths += [os.path.join(
+            os.path.expanduser("~"), ".config", "ripe-atlas-tools", "commands"
+        )]
+
+        r = [
+            package_name for _, package_name, _ in pkgutil.iter_modules(paths)
+        ]
+        r.remove("base")
+
+        return r
 
     def init_args(self, args=None):
         """
@@ -89,7 +112,8 @@ class Command(object):
         return args
 
     def ok(self, message):
-        sys.stdout.write("\n{}\n\n".format(colourise(message, "green")))
+        if sys.stdout.isatty():
+            sys.stdout.write("\n{}\n\n".format(colourise(message, "green")))
 
     @staticmethod
     def _get_user_agent():

--- a/ripe/atlas/tools/exceptions.py
+++ b/ripe/atlas/tools/exceptions.py
@@ -13,16 +13,15 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from ripe.atlas.tools.helpers.colours import colourise
+
 import sys
 
 
 class RipeAtlasToolsException(Exception):
 
-    RED = "\033[1;31m"
-    RESET = "\033[0m"
-
     def write(self):
         r = str(self)
-        if sys.stderr.isatty():
-            r = self.RED + r + self.RESET
-        sys.stderr.write("\n{0}\n\n".format(r))
+        sys.stderr.write("\n{0}\n\n".format(
+            colourise(r, "red", fileobj=sys.stderr))
+        )

--- a/ripe/atlas/tools/renderers/traceroute.py
+++ b/ripe/atlas/tools/renderers/traceroute.py
@@ -43,7 +43,7 @@ class Renderer(BaseRenderer):
                 else:
                     rtts.append("          *")
 
-            r += "{:>3} {:39} {}\n".format(
+            r += "{:>3} {:37} {}\n".format(
                 hop.index,
                 sanitise(name),
                 "  ".join(rtts)

--- a/ripe/atlas/tools/settings/__init__.py
+++ b/ripe/atlas/tools/settings/__init__.py
@@ -27,7 +27,7 @@ class Configuration(object):
     """
 
     USER_CONFIG_DIR = os.path.join(
-        os.environ["HOME"], ".config", "ripe-atlas-tools")
+        os.path.expanduser("~"), ".config", "ripe-atlas-tools")
     USER_RC = os.path.join(USER_CONFIG_DIR, "rc")
 
     DEFAULT = {

--- a/scripts/ripe-atlas
+++ b/scripts/ripe-atlas
@@ -2,11 +2,10 @@
 
 import importlib
 import os
-import pkgutil
 import re
 import sys
 
-from ripe.atlas.tools import commands
+from ripe.atlas.tools.commands.base import Command
 from ripe.atlas.tools.exceptions import RipeAtlasToolsException
 
 
@@ -17,32 +16,12 @@ class RipeAtlas(object):
         self.args = []
         self.kwargs = {}
 
-    @staticmethod
-    def _get_available_commands():
-        """
-        Get a list of commands that we can execute.  By default, we have a fixed
-        that we make available in this directory, but the user can create her
-        own plugins and store them at ~/.config/ripe-atlas-tools/commands/.  If
-        we find any files there, we add them to the list here.
-        """
-
-        paths = [os.path.dirname(commands.__file__)]
-
-        if "HOME" in os.environ:
-            paths += [os.path.join(
-                os.environ["HOME"], ".config", "ripe-atlas-tools", "commands")]
-
-        r = [package_name for _, package_name, _ in pkgutil.iter_modules(paths)]
-        r.remove("base")
-
-        return r
-
     def _setup_command(self):
 
         caller = os.path.basename(sys.argv[0])
         shortcut = re.match('^a(ping|traceroute|dig|sslcert|ntp|http)$', caller)
 
-        available_commands = self._get_available_commands()
+        available_commands = Command.get_available_commands()
         if shortcut:
             self.command = "measure"
             sys.argv.insert(1, self._translate_shortcut(shortcut.group(1)))
@@ -66,27 +45,25 @@ class RipeAtlas(object):
         self._setup_command()
 
         try:
-
             module = importlib.import_module(
                 "ripe.atlas.tools.commands.{}".format(self.command))
 
-            #
-            # If the imported module contains a `Factory` class, execute that
-            # to get the `cmd` we're going to use.  Otherwise, we expect there
-            # to be a `Command` class in there.
-            #
-
-            if hasattr(module, "Factory"):
-                cmd = module.Factory(*self.args, **self.kwargs).create()
-            else:
-                cmd = module.Command(*self.args, **self.kwargs)
-
-            cmd.init_args()
-            cmd.run()
-
         except ImportError:
-
             raise RipeAtlasToolsException("No such command.")
+
+        #
+        # If the imported module contains a `Factory` class, execute that
+        # to get the `cmd` we're going to use.  Otherwise, we expect there
+        # to be a `Command` class in there.
+        #
+
+        if hasattr(module, "Factory"):
+            cmd = module.Factory(*self.args, **self.kwargs).create()
+        else:
+            cmd = module.Command(*self.args, **self.kwargs)
+
+        cmd.init_args()
+        cmd.run()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
OK, let's try this again (replacing https://github.com/RIPE-NCC/ripe-atlas-tools/pull/148).

This request makes some small fixes to add Windows support.

There is also a small change moving the get_available_commands function from scripts/ripe-atlas to ripe/atlas/tools/commands/base.py. This is comparable to what already happens with ripe/atlas/tools/renderers/base.py, and allows me to override this function with pyinstaller (because scripts/ripe-atlas can't be imported from anywhere).