### PR TITLE
Make sure we have 80width for default output

### DIFF
--- a/ripe/atlas/tools/commands/measurements.py
+++ b/ripe/atlas/tools/commands/measurements.py
@@ -52,7 +52,7 @@ class Command(TabularFieldsMixin, BaseCommand):
     COLUMNS = {
         "id": ("<", 7),
         "type": ("<", 10),
-        "description": ("<", 45),
+        "description": ("<", 42),
         "status": (">", 18),
         "target": ("<", 45),
         "url": ("<", 45),

--- a/tests/commands/measurements.py
+++ b/tests/commands/measurements.py
@@ -96,15 +96,15 @@ class TestMeasurementsCommand(unittest.TestCase):
 
         expected_content = (
             "\n"
-            "Id      Type       Description                                               Status\n"
-            "===================================================================================\n"
-            "1       ping       Description 1                                            Ongoing\n"
-            "2       ping       Description 2                                            Ongoing\n"
-            "3       ping       Description 3                                            Ongoing\n"
-            "4       ping       Description 4                                            Ongoing\n"
-            "5       ping       Description 5                                            Ongoing\n"
-            "===================================================================================\n"
-            "                                                  Showing 5 of 5 total measurements\n"
+            "Id      Type       Description                                            Status\n"
+            "================================================================================\n"
+            "1       ping       Description 1                                         Ongoing\n"
+            "2       ping       Description 2                                         Ongoing\n"
+            "3       ping       Description 3                                         Ongoing\n"
+            "4       ping       Description 4                                         Ongoing\n"
+            "5       ping       Description 5                                         Ongoing\n"
+            "================================================================================\n"
+            "                                               Showing 5 of 5 total measurements\n"
             "\n"
         )
         self.assertEqual(


### PR DESCRIPTION
That's an easy fix for the default output. We were not counting spaces inbetween fields. Decreasing descr a bit it fixes the issue. If we need to do it for every custom output probably it's going to be a bit harder but we can see it later upon user's request.