### PR TITLE
Rename some commands

### DIFF
--- a/ripe/atlas/tools/commands/configure.py
+++ b/ripe/atlas/tools/commands/configure.py
@@ -27,8 +27,10 @@ class Command(BaseCommand):
 
     EDITOR = os.environ.get("EDITOR", "/usr/bin/vim")
     DESCRIPTION = "Adjust or initialize configuration options"
-    EXTRA_DESCRIPTION = "As an alternative to this command, you " \
-                  "can just create/edit {}".format(Configuration.USER_RC)
+    EXTRA_DESCRIPTION = (
+        "As an alternative to this command, you can just create/edit {}"
+        .format(Configuration.USER_RC)
+    )
 
     def add_arguments(self):
         self.parser.add_argument(

--- a/ripe/atlas/tools/commands/configure.py
+++ b/ripe/atlas/tools/commands/configure.py
@@ -26,8 +26,9 @@ class Command(BaseCommand):
     NAME = "configure"
 
     EDITOR = os.environ.get("EDITOR", "/usr/bin/vim")
-    DESCRIPTION = "An easy way to configure this tool. Alternatively, you " \
-                  "can always just create/edit {}".format(Configuration.USER_RC)
+    DESCRIPTION = "Adjust or initialize configuration options"
+    EXTRA_DESCRIPTION = "As an alternative to this command, you " \
+                  "can just create/edit {}".format(Configuration.USER_RC)
 
     def add_arguments(self):
         self.parser.add_argument(

--- a/ripe/atlas/tools/commands/measure/__init__.py
+++ b/ripe/atlas/tools/commands/measure/__init__.py
@@ -37,6 +37,7 @@ class Factory(BaseFactory):
         "http": HttpMeasureCommand,
         "ntp": NtpMeasureCommand,
     }
+    DESCRIPTION = "Create a measurement and wait for the results"
 
     def __init__(self):
 
@@ -55,7 +56,13 @@ class Factory(BaseFactory):
             (len(sys.argv) == 2 and sys.argv[1] in ("--help", "-h"))
         ):
             log = (
-                "For extended options for a specific measurement type, "
+                "Usage: ripe-atlas measure <type> [arguments]\n\n"
+                "Types:\n"
+            )
+            for type_ in sorted(self.TYPES):
+                log += "\t{}\n".format(type_)
+            log += (
+                "\nFor extended options for a specific measurement type, "
                 "try ripe-atlas measure <type> --help."
             )
         # cases: ripe-atlas measure bla

--- a/ripe/atlas/tools/commands/measurement_info.py
+++ b/ripe/atlas/tools/commands/measurement_info.py
@@ -26,9 +26,9 @@ from ..helpers.sanitisers import sanitise
 
 class Command(MetaDataMixin, BaseCommand):
 
-    NAME = "measurement"
+    NAME = "measurement-info"
     DESCRIPTION = (
-        "Returns the meta data for one measurement"
+        "Return the meta data for one measurement"
     )
 
     def add_arguments(self):

--- a/ripe/atlas/tools/commands/measurement_search.py
+++ b/ripe/atlas/tools/commands/measurement_search.py
@@ -27,7 +27,7 @@ from ..helpers.validators import ArgumentType
 
 class Command(TabularFieldsMixin, BaseCommand):
 
-    NAME = "measurements"
+    NAME = "measurement-search"
     LIMITS = (1, 1000)
 
     STATUS_SPECIFIED = 0
@@ -59,8 +59,8 @@ class Command(TabularFieldsMixin, BaseCommand):
     }
 
     DESCRIPTION = (
-        "Fetches and prints measurements fulfilling specified criteria based "
-        "on given filters."
+        "Fetch and print measurements fulfilling specified criteria based "
+        "on given filters"
     )
 
     def add_arguments(self):

--- a/ripe/atlas/tools/commands/probe_info.py
+++ b/ripe/atlas/tools/commands/probe_info.py
@@ -26,8 +26,8 @@ from ..helpers.sanitisers import sanitise
 
 class Command(MetaDataMixin, BaseCommand):
 
-    NAME = "probe"
-    DESCRIPTION = "Returns the meta data for one probe"
+    NAME = "probe-info"
+    DESCRIPTION = "Return the meta data for one probe"
 
     def add_arguments(self):
         self.parser.add_argument("id", type=int, help="The probe id")

--- a/ripe/atlas/tools/commands/probe_search.py
+++ b/ripe/atlas/tools/commands/probe_search.py
@@ -31,11 +31,11 @@ from ..helpers.validators import ArgumentType
 
 class Command(TabularFieldsMixin, BaseCommand):
 
-    NAME = "probes"
+    NAME = "probe-search"
 
     DESCRIPTION = (
-        "Fetches and prints probes fulfilling specified criteria based on "
-        "given filters."
+        "Fetch and print probes fulfilling specified criteria based on "
+        "given filters"
     )
 
     # Column name: (alignment, width)

--- a/ripe/atlas/tools/commands/render.py
+++ b/ripe/atlas/tools/commands/render.py
@@ -37,8 +37,14 @@ class Command(BaseCommand):
 
     NAME = "render"
 
-    DESCRIPTION = "Render the contents of an arbitrary file.\n\nExample:\n" \
-                  "  cat /my/file | ripe-atlas render\n"
+    DESCRIPTION = (
+        "Render measurement results from a file or standard input"
+    )
+
+    EXTRA_DESCRIPTION = (
+        "Example:\n"
+        "  cat /my/file | ripe-atlas render\n"
+    )
 
     AGGREGATORS = {
         "country": ["probe.country_code", ValueKeyAggregator],

--- a/ripe/atlas/tools/commands/report.py
+++ b/ripe/atlas/tools/commands/report.py
@@ -33,8 +33,11 @@ class Command(BaseCommand):
 
     NAME = "report"
 
-    DESCRIPTION = "Report the results of a measurement.\n\nExample:\n" \
-                  "  ripe-atlas report 1001 --probes 157,10006\n"
+    DESCRIPTION = "Report the results of an already created measurement"
+    EXTRA_DESCRIPTION = (
+        "Example:\n"
+        "  ripe-atlas report 1001 --probes 157,10006"
+    )
 
     AGGREGATORS = {
         "country": ["probe.country_code", ValueKeyAggregator],

--- a/ripe/atlas/tools/commands/stream.py
+++ b/ripe/atlas/tools/commands/stream.py
@@ -29,7 +29,9 @@ class Command(BaseCommand):
 
     NAME = "stream"
 
-    DESCRIPTION = "Report the results of a measurement"
+    DESCRIPTION = (
+        "Output the results of a measurement as they become available"
+    )
     URLS = {
         "detail": "/api/v2/measurements/{0}.json",
     }

--- a/scripts/ripe-atlas
+++ b/scripts/ripe-atlas
@@ -1,38 +1,75 @@
 #!/usr/bin/env python
 
-import importlib
 import os
 import re
 import sys
 
-from ripe.atlas.tools.commands.base import Command
+from ripe.atlas.tools.commands.base import Command, Factory
 from ripe.atlas.tools.exceptions import RipeAtlasToolsException
+from ripe.atlas.tools.helpers.colours import colourise
 
 
 class RipeAtlas(object):
+
+    DEPRECATED_ALIASES = {
+        "measurement": "measurement-info",
+        "measurements": "measurement-search",
+        "probe": "probe-info",
+        "probes": "probe-search",
+    }
 
     def __init__(self):
         self.command = None
         self.args = []
         self.kwargs = {}
 
+    def _show_usage(self):
+        usage = "Usage: ripe-atlas <command> [arguments]\n\n"
+        usage += "Commands:\n"
+        longest_command = 0
+        classes = []
+        for c in Command.get_available_commands():
+            if c == "shibboleet":
+                continue
+            cmd_class = Command.load_command_class(c)
+            classes.append(cmd_class)
+            cmd_name = cmd_class.get_name()
+            if len(cmd_name) > longest_command:
+                longest_command = len(cmd_name)
+        for cmd_cls in classes:
+            usage += "\t{} {}\n".format(
+                cmd_cls.get_name().ljust(longest_command + 1),
+                cmd_cls.DESCRIPTION,
+            )
+        usage += (
+            "\nFor help on a particular command, try "
+            "ripe-atlas <command> --help"
+        )
+        raise RipeAtlasToolsException(usage)
+
     def _setup_command(self):
 
         caller = os.path.basename(sys.argv[0])
         shortcut = re.match('^a(ping|traceroute|dig|sslcert|ntp|http)$', caller)
 
-        available_commands = Command.get_available_commands()
         if shortcut:
             self.command = "measure"
             sys.argv.insert(1, self._translate_shortcut(shortcut.group(1)))
         else:
             if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
-                raise RipeAtlasToolsException(
-                    "Usage: ripe-atlas <{}> [arguments]".format(
-                        "|".join(set(available_commands) - {"shibboleet"})
-                    )
-                )
-            self.command = sys.argv.pop(1)
+                self._show_usage()
+            cmd_name = sys.argv.pop(1)
+            if cmd_name in self.DEPRECATED_ALIASES:
+                alias = cmd_name
+                self.command = self.DEPRECATED_ALIASES[alias]
+                sys.stderr.write(colourise(
+                    "Warning: {} is a deprecated alias for {}\n\n".format(
+                        alias, self.command,
+                    ),
+                    "yellow"
+                ))
+            else:
+                self.command = cmd_name
 
     @staticmethod
     def _translate_shortcut(shortcut):
@@ -44,33 +81,22 @@ class RipeAtlas(object):
 
         self._setup_command()
 
-        module_name = "ripe.atlas.tools.commands.{}".format(self.command)
+        cmd_cls = Command.load_command_class(self.command)
 
-        try:
-            module = importlib.import_module(module_name)
+        if cmd_cls is None:
+            # Module containing the command class wasn't found
+            raise RipeAtlasToolsException("No such command")
 
-        except ImportError as exc:
-            if hasattr(exc, "name"):
-                # Python 3.3+, exc.name will be the full module path
-                is_command_module = exc.name == module_name
-            else:
-                # Python 2.7, message will contain the final part of the path
-                is_command_module = exc.args[0].rsplit(
-                    " ", 1)[-1] == self.command
-            if is_command_module:
-                raise RipeAtlasToolsException("No such command.")
-            else:
-                raise  # We're missing a dependency
         #
         # If the imported module contains a `Factory` class, execute that
         # to get the `cmd` we're going to use.  Otherwise, we expect there
         # to be a `Command` class in there.
         #
 
-        if hasattr(module, "Factory"):
-            cmd = module.Factory(*self.args, **self.kwargs).create()
+        if issubclass(cmd_cls, Factory):
+            cmd = cmd_cls(*self.args, **self.kwargs).create()
         else:
-            cmd = module.Command(*self.args, **self.kwargs)
+            cmd = cmd_cls(*self.args, **self.kwargs)
 
         cmd.init_args()
         cmd.run()

--- a/scripts/ripe-atlas
+++ b/scripts/ripe-atlas
@@ -11,13 +11,6 @@ from ripe.atlas.tools.helpers.colours import colourise
 
 class RipeAtlas(object):
 
-    DEPRECATED_ALIASES = {
-        "measurement": "measurement-info",
-        "measurements": "measurement-search",
-        "probe": "probe-info",
-        "probes": "probe-search",
-    }
-
     def __init__(self):
         self.command = None
         self.args = []
@@ -58,18 +51,7 @@ class RipeAtlas(object):
         else:
             if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
                 raise RipeAtlasToolsException(self._generate_usage())
-            cmd_name = sys.argv.pop(1)
-            if cmd_name in self.DEPRECATED_ALIASES:
-                alias = cmd_name
-                self.command = self.DEPRECATED_ALIASES[alias]
-                sys.stderr.write(colourise(
-                    "Warning: {} is a deprecated alias for {}\n\n".format(
-                        alias, self.command,
-                    ),
-                    "yellow"
-                ))
-            else:
-                self.command = cmd_name
+            self.command = sys.argv.pop(1)
 
     @staticmethod
     def _translate_shortcut(shortcut):

--- a/scripts/ripe-atlas
+++ b/scripts/ripe-atlas
@@ -23,7 +23,7 @@ class RipeAtlas(object):
         self.args = []
         self.kwargs = {}
 
-    def _show_usage(self):
+    def _generate_usage(self):
         usage = "Usage: ripe-atlas <command> [arguments]\n\n"
         usage += "Commands:\n"
         longest_command = 0
@@ -45,7 +45,7 @@ class RipeAtlas(object):
             "\nFor help on a particular command, try "
             "ripe-atlas <command> --help"
         )
-        raise RipeAtlasToolsException(usage)
+        return usage
 
     def _setup_command(self):
 
@@ -57,7 +57,7 @@ class RipeAtlas(object):
             sys.argv.insert(1, self._translate_shortcut(shortcut.group(1)))
         else:
             if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
-                self._show_usage()
+                raise RipeAtlasToolsException(self._generate_usage())
             cmd_name = sys.argv.pop(1)
             if cmd_name in self.DEPRECATED_ALIASES:
                 alias = cmd_name

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,7 +18,8 @@ from .commands import (
     TestProbesCommand,
     TestMeasureCommand,
     TestMeasurementsCommand,
-    TestReportCommand
+    TestReportCommand,
+    TestCommandLoading,
 )
 from .helpers import TestArgumentTypeHelper
 from .renderers import (
@@ -36,6 +37,7 @@ __all__ = [
     TestMeasureCommand,
     TestMeasurementsCommand,
     TestReportCommand,
+    TestCommandLoading,
     TestArgumentTypeHelper,
     TestPingRenderer,
     TestHttpRenderer,

--- a/tests/commands/__init__.py
+++ b/tests/commands/__init__.py
@@ -14,8 +14,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from .measure import TestMeasureCommand
-from .measurements import TestMeasurementsCommand
-from .probes import TestProbesCommand
+from .measurement_search import TestMeasurementsCommand
+from .probe_search import TestProbesCommand
 from .report import TestReportCommand
 
 __all__ = [

--- a/tests/commands/__init__.py
+++ b/tests/commands/__init__.py
@@ -17,10 +17,12 @@ from .measure import TestMeasureCommand
 from .measurement_search import TestMeasurementsCommand
 from .probe_search import TestProbesCommand
 from .report import TestReportCommand
+from .loading import TestCommandLoading
 
 __all__ = [
     TestMeasureCommand,
     TestMeasurementsCommand,
     TestProbesCommand,
-    TestReportCommand
+    TestReportCommand,
+    TestCommandLoading,
 ]

--- a/tests/commands/loading.py
+++ b/tests/commands/loading.py
@@ -4,7 +4,12 @@ import unittest
 import tempfile
 import shutil
 import sys
-import StringIO
+# Python 2.7 does have io.StringIO but StringIO. is more liberal regarding str
+# versus unicode inputs to write()
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 from ripe.atlas.tools.commands.base import Command
 
@@ -89,7 +94,7 @@ class TestCommandLoading(unittest.TestCase):
 
         # Check that each alias is loaded correctly and outputs a warning
         stderr = sys.stderr
-        sys.stderr = StringIO.StringIO()
+        sys.stderr = StringIO()
         try:
             for alias, cmd_name in aliases:
                 sys.stderr.truncate()

--- a/tests/commands/loading.py
+++ b/tests/commands/loading.py
@@ -1,0 +1,110 @@
+import mock
+import os.path
+import unittest
+import tempfile
+import shutil
+import sys
+import StringIO
+
+from ripe.atlas.tools.commands.base import Command
+import ripe.atlas.tools.commands
+
+
+USER_COMMAND = """
+from ripe.atlas.tools.commands.base import Command as BaseCommand
+
+class Command(BaseCommand):
+    NAME = 'user-command-1'
+"""
+
+
+class TestCommandLoading(unittest.TestCase):
+    user_dir = os.path.join(
+        os.path.expanduser("~"), ".config", "ripe-atlas-tools", "commands"
+    )
+    command_dir = os.path.dirname(ripe.atlas.tools.commands.__file__)
+
+    expected_builtins = [
+        "configure",
+        "go",
+        "measure",
+        "measurement-info",
+        "measurement-search",
+        "probe-info",
+        "probe-search",
+        "render",
+        "report",
+        "shibboleet",
+        "stream",
+    ]
+
+    def setUp(self):
+        # Create a directory for storing user commands and insert the dummy
+        # command
+        self.user_command_path = tempfile.mkdtemp()
+        with open(
+            os.path.join(self.user_command_path, "user_command_1.py"),
+            "w"
+        ) as f:
+            f.write(USER_COMMAND)
+
+    def tearDown(self):
+        shutil.rmtree(self.user_command_path)
+
+    @mock.patch(
+        "ripe.atlas.tools.commands.base.Command._get_user_command_path",
+        return_value=None,
+    )
+    def test_command_loading(self, _get_user_command_path):
+        _get_user_command_path.return_value = self.user_command_path
+
+        available_commands = Command.get_available_commands()
+
+        # Check that we have the command list that we expect
+        self.assertEquals(
+            sorted(available_commands),
+            sorted(
+                [b.replace('-', '_') for b in self.expected_builtins] +
+                ["user_command_1"]
+            ),
+        )
+
+        # Check that we can load (i.e. import) every builtin command
+        for expected_builtin in self.expected_builtins:
+            self.assertIn(expected_builtin.replace("-", "_"), available_commands)
+            cmd_cls = Command.load_command_class(expected_builtin)
+            self.assertIsNotNone(cmd_cls)
+            self.assertEquals(cmd_cls.get_name(), expected_builtin)
+
+        # Check that we can load the user command
+        user_cmd_cls = Command.load_command_class("user-command-1")
+        self.assertIsNotNone(user_cmd_cls)
+        self.assertEquals(user_cmd_cls.get_name(), "user-command-1")
+
+        # Check that load_command_class() returns None for junk commands
+        unexpected_cmd = Command.load_command_class("no-such-command")
+        self.assertIsNone(unexpected_cmd)
+
+    def test_deprecated_aliases(self):
+        aliases = [
+            ("measurement", "measurement-info"),
+            ("measurements", "measurement-search"),
+            ("probe", "probe-info"),
+            ("probes", "probe-search"),
+        ]
+
+        # Check that each alias is loaded correctly and outputs a warning
+        stderr = sys.stderr
+        sys.stderr = StringIO.StringIO()
+        try:
+            for alias, cmd_name in aliases:
+                sys.stderr.truncate()
+                cmd_cls = Command.load_command_class(alias)
+                self.assertIn(
+                    "{} is a deprecated alias for {}".format(alias, cmd_name),
+                    sys.stderr.getvalue(),
+                )
+                self.assertIsNotNone(cmd_cls)
+                self.assertEquals(cmd_cls.get_name(), cmd_name)
+        finally:
+            sys.stderr = stderr

--- a/tests/commands/loading.py
+++ b/tests/commands/loading.py
@@ -7,7 +7,6 @@ import sys
 import StringIO
 
 from ripe.atlas.tools.commands.base import Command
-import ripe.atlas.tools.commands
 
 
 USER_COMMAND = """
@@ -19,11 +18,6 @@ class Command(BaseCommand):
 
 
 class TestCommandLoading(unittest.TestCase):
-    user_dir = os.path.join(
-        os.path.expanduser("~"), ".config", "ripe-atlas-tools", "commands"
-    )
-    command_dir = os.path.dirname(ripe.atlas.tools.commands.__file__)
-
     expected_builtins = [
         "configure",
         "go",

--- a/tests/commands/measurement_search.py
+++ b/tests/commands/measurement_search.py
@@ -23,9 +23,11 @@ try:
 except ImportError:
     import mock
 
-from ripe.atlas.tools.commands.measurements import Command
+from ripe.atlas.tools.commands.measurement_search import Command
 
 from ..base import capture_sys_output
+
+COMMAND_MODULE = "ripe.atlas.tools.commands.measurement_search"
 
 
 class FakeGen(object):
@@ -84,7 +86,7 @@ class FakeGen(object):
 
 class TestMeasurementsCommand(unittest.TestCase):
 
-    @mock.patch("ripe.atlas.tools.commands.measurements.MeasurementRequest")
+    @mock.patch("{}.MeasurementRequest".format(COMMAND_MODULE))
     def test_with_empty_args(self, mock_request):
 
         mock_request.return_value = FakeGen()
@@ -114,7 +116,7 @@ class TestMeasurementsCommand(unittest.TestCase):
         self.assertEqual(
             cmd.arguments.field, ("id", "type", "description", "status"))
 
-    @mock.patch("ripe.atlas.tools.commands.measurements.MeasurementRequest")
+    @mock.patch("{}.MeasurementRequest".format(COMMAND_MODULE))
     def test_get_line_items(self, mock_request):
 
         mock_request.return_value = FakeGen()

--- a/tests/commands/probe_search.py
+++ b/tests/commands/probe_search.py
@@ -17,12 +17,15 @@ import mock
 import unittest
 import requests
 
-from ripe.atlas.tools.commands.probes import Command
+from ripe.atlas.tools.commands.probe_search import Command
 from ripe.atlas.tools.exceptions import RipeAtlasToolsException
 from ripe.atlas.cousteau import Probe
 from ripe.atlas.tools.aggregators import ValueKeyAggregator
 
 from ..base import capture_sys_output
+
+
+COMMAND_MODULE = "ripe.atlas.tools.commands.probe_search"
 
 
 class FakeGen(object):
@@ -291,7 +294,7 @@ class TestProbesCommand(unittest.TestCase):
             "--prefixv4", "193.0.0.0/21"
         ])
 
-        path = 'ripe.atlas.tools.commands.probes.Command.location2degrees'
+        path = '{}.Command.location2degrees'.format(COMMAND_MODULE)
         with mock.patch(path) as mock_get:
             mock_get.return_value = (1, 2)
             self.assertEquals(cmd.build_request_args(), {
@@ -324,7 +327,7 @@ class TestProbesCommand(unittest.TestCase):
         ])
 
         with capture_sys_output() as (stdout, stderr):
-            path = 'ripe.atlas.tools.commands.probes.ProbeRequest'
+            path = '{}.ProbeRequest'.format(COMMAND_MODULE)
             with mock.patch(path) as mock_get:
                 mock_get.return_value = FakeGen()
                 cmd.run()
@@ -340,7 +343,7 @@ class TestProbesCommand(unittest.TestCase):
         ])
 
         with capture_sys_output() as (stdout, stderr):
-            path = 'ripe.atlas.tools.commands.probes.ProbeRequest'
+            path = '{}.ProbeRequest'.format(COMMAND_MODULE)
             with mock.patch(path) as mock_get:
                 mock_get.return_value = FakeGen()
                 cmd.run()
@@ -358,7 +361,7 @@ class TestProbesCommand(unittest.TestCase):
         ])
 
         with capture_sys_output() as (stdout, stderr):
-            path = 'ripe.atlas.tools.commands.probes.ProbeRequest'
+            path = '{}.ProbeRequest'.format(COMMAND_MODULE)
             with mock.patch(path) as mock_get:
                 mock_get.return_value = FakeGen()
                 cmd.run()
@@ -393,7 +396,7 @@ class TestProbesCommand(unittest.TestCase):
         ])
 
         with capture_sys_output() as (stdout, stderr):
-            path = 'ripe.atlas.tools.commands.probes.ProbeRequest'
+            path = '{}.ProbeRequest'.format(COMMAND_MODULE)
             with mock.patch(path) as mock_get:
                 mock_get.return_value = FakeGen()
                 cmd.run()
@@ -424,7 +427,7 @@ class TestProbesCommand(unittest.TestCase):
         ])
 
         with capture_sys_output() as (stdout, stderr):
-            path = 'ripe.atlas.tools.commands.probes.ProbeRequest'
+            path = 'ripe.atlas.tools.commands.probe_search.ProbeRequest'
             with mock.patch(path) as mock_get:
                 mock_get.return_value = FakeGen()
                 cmd.run()
@@ -454,7 +457,7 @@ class TestProbesCommand(unittest.TestCase):
         ])
 
         with capture_sys_output() as (stdout, stderr):
-            path = 'ripe.atlas.tools.commands.probes.ProbeRequest'
+            path = '{}.ProbeRequest'.format(COMMAND_MODULE)
             with mock.patch(path) as mock_get:
                 mock_get.return_value = FakeGen()
                 cmd.run()
@@ -503,7 +506,7 @@ class TestProbesCommand(unittest.TestCase):
         ])
 
         with capture_sys_output() as (stdout, stderr):
-            path = 'ripe.atlas.tools.commands.probes.ProbeRequest'
+            path = '{}.ProbeRequest'.format(COMMAND_MODULE)
             with mock.patch(path) as mock_get:
                 mock_get.return_value = FakeGen()
                 cmd.run()
@@ -540,7 +543,7 @@ class TestProbesCommand(unittest.TestCase):
         ])
 
         with capture_sys_output() as (stdout, stderr):
-            path = 'ripe.atlas.tools.commands.probes.ProbeRequest'
+            path = '{}.ProbeRequest'.format(COMMAND_MODULE)
             with mock.patch(path) as mock_get:
                 mock_get.return_value = FakeGen()
                 cmd.run()


### PR DESCRIPTION
Summary of changes:

1. Renamed some commands
2. Made the help text more informative and consistent
3. Refactored the command import code

### 1
We found that users were confused by similar-looking commands like measure/measurement/measurements and probe/probes. This change makes the following renames, preserving backwards compatibility using deprecated aliases:

- measurement -> measurement-info
- measurements -> measurement-search
- probe -> probe-info
- probes -> probe-search

### 2
I made the help text more consistent in tense, and a few other tweaks. I also changed to provide a short description of the commands when you run "ripe-atlas --help", and a list of measurement types when you run "ripe-atlas measure --help".

### 3
I have also refactored some of the import code so that

1. we can support dashes in the subcommand names (underscores are less intuitive when the command itself is called ripeDASHatlas)
2. we can support (non-deprecating) aliases in the future, as we have been discussing
3. custom commands in the ~/.config directory works again (did it ever work?)