### PR TITLE
Fixes partially #113, as it adds auto-completion for bash shell

### DIFF
--- a/ripe-atlas-bash-completion.sh
+++ b/ripe-atlas-bash-completion.sh
@@ -1,0 +1,13 @@
+## This is highly inspired from Django's manage.py autocompletion
+## https://github.com/django/django/blob/1.9.4/extras/django_bash_completion#L42-L57
+## To install this, add the following line to your .bash_profile:
+##
+## . ~/path/to/django_bash_completion
+
+_ripe_atlas_bash_completion()
+{
+    COMPREPLY=( $( COMP_WORDS="${COMP_WORDS[*]}" \
+                   COMP_CWORD=$COMP_CWORD \
+                   RIPE_ATLAS_AUTO_COMPLETE=1 $1 ) )
+}
+complete -F _ripe_atlas_bash_completion -o default ripe-atlas

--- a/ripe/atlas/tools/commands/measure/__init__.py
+++ b/ripe/atlas/tools/commands/measure/__init__.py
@@ -15,8 +15,6 @@
 
 from __future__ import print_function, absolute_import
 
-import sys
-
 from ...exceptions import RipeAtlasToolsException
 from ..base import Factory as BaseFactory
 from .ping import PingMeasureCommand
@@ -39,11 +37,12 @@ class Factory(BaseFactory):
     }
     DESCRIPTION = "Create a measurement and wait for the results"
 
-    def __init__(self):
+    def __init__(self, sys_args):
 
         self.build_class = None
-        if len(sys.argv) >= 2:
-            self.build_class = self.TYPES.get(sys.argv[1].lower())
+        self.sys_args = sys_args
+        if len(self.sys_args) >= 2:
+            self.build_class = self.TYPES.get(self.sys_args[1].lower())
 
         if not self.build_class:
             self.raise_log()
@@ -52,8 +51,8 @@ class Factory(BaseFactory):
         """Depending on the input raise with different log message."""
         # cases: 1) ripe-atlas measure 2) ripe-atlas measure --help/-h
         if (
-            len(sys.argv) == 1 or
-            (len(sys.argv) == 2 and sys.argv[1] in ("--help", "-h"))
+            len(self.sys_args) == 1 or
+            (len(self.sys_args) == 2 and self.sys_args[1] in ("--help", "-h"))
         ):
             log = (
                 "Usage: ripe-atlas measure <type> [arguments]\n\n"

--- a/scripts/ripe-atlas
+++ b/scripts/ripe-atlas
@@ -5,8 +5,8 @@ import re
 import sys
 
 from ripe.atlas.tools.commands.base import Command, Factory
+from ripe.atlas.tools.commands.measure import Factory as BaseFactory
 from ripe.atlas.tools.exceptions import RipeAtlasToolsException
-from ripe.atlas.tools.helpers.colours import colourise
 
 
 class RipeAtlas(object):
@@ -40,18 +40,24 @@ class RipeAtlas(object):
         )
         return usage
 
-    def _setup_command(self):
-
+    def _set_base_command(self):
+        """
+        Sets the base command covering cases where we call it with
+        shortcut or asking for help.
+        """
         caller = os.path.basename(sys.argv[0])
         shortcut = re.match('^a(ping|traceroute|dig|sslcert|ntp|http)$', caller)
 
         if shortcut:
             self.command = "measure"
             sys.argv.insert(1, self._translate_shortcut(shortcut.group(1)))
-        else:
-            if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
-                raise RipeAtlasToolsException(self._generate_usage())
-            self.command = sys.argv.pop(1)
+            return
+
+        if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help"):
+            self.command = "help"
+            return
+
+        self.command = sys.argv.pop(1)
 
     @staticmethod
     def _translate_shortcut(shortcut):
@@ -59,11 +65,55 @@ class RipeAtlas(object):
             return "dns"
         return shortcut
 
-    def main(self):
+    def autocomplete(self):
+        """
+        This function and it's is highly inspired from Django's own autocomplete
+        manage.py. For more documentation check
+        https://github.com/django/django/blob/1.9.4/django/core/management/__init__.py#L198-L270
+        """
 
-        self._setup_command()
+        def print_options(options, curr):
+            """
+            Prints matching with current word available autocomplete options
+            in a formatted way to look good on bash.
+            """
+            sys.stdout.write(' '.join(sorted(filter(lambda x: x.startswith(curr), options))))
 
-        cmd_cls = Command.load_command_class(self.command)
+        # If we are not autocompleting continue as normal
+        if 'RIPE_ATLAS_AUTO_COMPLETE' not in os.environ:
+            return
+
+        cwords = os.environ['COMP_WORDS'].split()[1:]
+        cword = int(os.environ['COMP_CWORD'])
+
+        try:
+            curr = cwords[cword - 1]
+        except IndexError:
+            curr = ''
+
+        commands = list(Command.get_available_commands())
+
+        # base caller ripe-atlas
+        if cword == 1:
+            print_options(commands, curr)
+        # special measure command
+        elif cword == 2 and cwords[0] == "measure":
+            print_options(BaseFactory.TYPES.keys(), curr)
+        # rest of commands
+        elif cwords[0] in commands:
+            cmd = self.fetch_command_class(cwords[0], cwords)
+            cmd.add_arguments()
+            options = [sorted(s_opt.option_strings)[0] for s_opt in cmd.parser._actions if s_opt.option_strings]
+            previous_options = [x for x in cwords[1:cword - 1]]
+            options = [opt for opt in options if opt not in previous_options]
+            print_options(options, curr)
+
+        sys.exit(1)
+
+    def fetch_command_class(self, command, arg_options):
+        """Fetches the class responsible for the given command."""
+
+        cmd_cls = Command.load_command_class(command)
 
         if cmd_cls is None:
             # Module containing the command class wasn't found
@@ -76,10 +126,22 @@ class RipeAtlas(object):
         #
 
         if issubclass(cmd_cls, Factory):
-            cmd = cmd_cls(*self.args, **self.kwargs).create()
+            cmd = cmd_cls(arg_options).create()
         else:
             cmd = cmd_cls(*self.args, **self.kwargs)
 
+        return cmd
+
+    def main(self):
+
+        self._set_base_command()
+
+        self.autocomplete()
+
+        if self.command == "help":
+            raise RipeAtlasToolsException(self._generate_usage())
+
+        cmd = self.fetch_command_class(self.command, sys.argv)
         cmd.init_args()
         cmd.run()
 

--- a/scripts/ripe-atlas
+++ b/scripts/ripe-atlas
@@ -67,7 +67,7 @@ class RipeAtlas(object):
 
     def autocomplete(self):
         """
-        This function and it's is highly inspired from Django's own autocomplete
+        This function is highly inspired from Django's own autocomplete
         manage.py. For more documentation check
         https://github.com/django/django/blob/1.9.4/django/core/management/__init__.py#L198-L270
         """

--- a/tests/test_bash_completion.py
+++ b/tests/test_bash_completion.py
@@ -1,0 +1,70 @@
+import os
+import unittest
+import subprocess
+
+
+class BashCompletionTests(unittest.TestCase):
+    """
+    Testing the Python level bash completion code.
+    This requires setting up the environment as if we got passed data
+    from bash.
+    """
+
+    def setUp(self):
+        os.environ['RIPE_ATLAS_AUTO_COMPLETE'] = '1'
+
+    def _setup_env(self, substring):
+        input_str = "ripe-atlas" + substring
+        os.environ['COMP_WORDS'] = input_str
+        idx = len(input_str.split(' ')) - 1  # Index of the last word
+        comp_cword = idx + 1 if substring.strip() and substring.endswith(' ') else idx
+        os.environ['COMP_CWORD'] = str(comp_cword)
+
+    def _autocomplete(self, substring):
+
+        self._setup_env(substring)
+        cmd_parts = "ripe-atlas"
+        if substring:
+            cmd_parts = ["ripe-atlas", substring]
+        envs = os.environ.copy()
+        process = subprocess.Popen(
+            cmd_parts, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=envs
+        )
+        output, error = process.communicate()
+        return output, error
+
+    def test_commands_completion(self):
+        """Tests autocompletion of commands."""
+        input_str = " "
+        output, _ = self._autocomplete(input_str)
+        self.assertTrue("measure" in output)
+
+    def test_completion_disable(self):
+        """
+        Tests if autocompletion is disabled if environmental variable
+        is not set.
+        """
+        input_str = " "
+        del os.environ['RIPE_ATLAS_AUTO_COMPLETE']
+        _, error = self._autocomplete(input_str)
+        self.assertTrue("No such command" in error)
+
+    def test_command_completion(self):
+        """Tests autocompletion of specific command."""
+        input_str = " meas"
+        output, _ = self._autocomplete(input_str)
+        self.assertTrue("measure" in output)
+
+    def test_options_completion(self):
+        """Tests autocompletion of existing options for a command."""
+        input_str = " report "
+        output, _ = self._autocomplete(input_str)
+        output = output.strip().split('\n')
+        for item in output:
+            self.assertTrue(item.startswith('--'))
+
+    def test_option_completion(self):
+        """Tests autocompletion of specific option of a command."""
+        input_str = " report --h"
+        output, _ = self._autocomplete(input_str)
+        self.assertEquals(output, "--help")

--- a/tests/test_bash_completion.py
+++ b/tests/test_bash_completion.py
@@ -31,7 +31,7 @@ class BashCompletionTests(unittest.TestCase):
             cmd_parts, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=envs
         )
         output, error = process.communicate()
-        return output, error
+        return output.decode("utf-8"), error.decode("utf-8")
 
     def test_commands_completion(self):
         """Tests autocompletion of commands."""

--- a/tests/test_bash_completion.py
+++ b/tests/test_bash_completion.py
@@ -67,4 +67,4 @@ class BashCompletionTests(unittest.TestCase):
         """Tests autocompletion of specific option of a command."""
         input_str = " report --h"
         output, _ = self._autocomplete(input_str)
-        self.assertEquals(output, "--help")
+        self.assertEqual(output, "--help")

--- a/tests/test_bash_completion.py
+++ b/tests/test_bash_completion.py
@@ -16,19 +16,16 @@ class BashCompletionTests(unittest.TestCase):
     def _setup_env(self, substring):
         input_str = "ripe-atlas" + substring
         os.environ['COMP_WORDS'] = input_str
-        idx = len(input_str.split(' ')) - 1  # Index of the last word
-        comp_cword = idx + 1 if substring.strip() and substring.endswith(' ') else idx
+        comp_cword = len(input_str.split(' ')) - 1  # Index of the last word
         os.environ['COMP_CWORD'] = str(comp_cword)
 
     def _autocomplete(self, substring):
 
         self._setup_env(substring)
-        cmd_parts = "ripe-atlas"
-        if substring:
-            cmd_parts = ["ripe-atlas", substring]
+        cmd_parts = "ripe-atlas" + substring
         envs = os.environ.copy()
         process = subprocess.Popen(
-            cmd_parts, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=envs
+            cmd_parts, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=envs, shell=True
         )
         output, error = process.communicate()
         return output.decode("utf-8"), error.decode("utf-8")
@@ -36,35 +33,38 @@ class BashCompletionTests(unittest.TestCase):
     def test_commands_completion(self):
         """Tests autocompletion of commands."""
         input_str = " "
-        output, _ = self._autocomplete(input_str)
-        self.assertTrue("measure" in output)
+        output, error = self._autocomplete(input_str)
+        print(output, error)
+        self.assertTrue("report" in output)
 
     def test_completion_disable(self):
         """
         Tests if autocompletion is disabled if environmental variable
         is not set.
         """
-        input_str = " "
+        input_str = " mea"
         del os.environ['RIPE_ATLAS_AUTO_COMPLETE']
-        _, error = self._autocomplete(input_str)
+        output, error = self._autocomplete(input_str)
+        print(output, error)
         self.assertTrue("No such command" in error)
 
     def test_command_completion(self):
         """Tests autocompletion of specific command."""
         input_str = " meas"
-        output, _ = self._autocomplete(input_str)
+        output, error = self._autocomplete(input_str)
+        print(output, error)
         self.assertTrue("measure" in output)
 
     def test_options_completion(self):
         """Tests autocompletion of existing options for a command."""
-        input_str = " report "
-        output, _ = self._autocomplete(input_str)
-        output = output.strip().split('\n')
-        for item in output:
-            self.assertTrue(item.startswith('--'))
+        input_str = " measure "
+        output, error = self._autocomplete(input_str)
+        print(output, error)
+        self.assertEqual(output, "dns http ntp ping sslcert traceroute")
 
     def test_option_completion(self):
         """Tests autocompletion of specific option of a command."""
-        input_str = " report --h"
-        output, _ = self._autocomplete(input_str)
+        input_str = " measure ping --h"
+        output, error = self._autocomplete(input_str)
+        print(output, error)
         self.assertEqual(output, "--help")


### PR DESCRIPTION
This is highly inspired from how Django is doing auto-completion. It
uses bash's complete build in function to get the available options
there are for each input. The main idea is that now we have a function
that can intervene the normal execution of ripe-atlas script and can
return back available options in a format compatible with what
bash's complete function expects. This function will intervene
only if we have an enviromental variable set, which is what
ripe-atlas-bash-completion.sh is taking care of. I had to do
changes in ripe-atlas script to make sure I can get all available
options any time without getting to the execution logic of any command
and also make sure ripe-atlas script won't return before autocomplete
function has run.