### PR TITLE
Proposed PR for issue #164.

### DIFF
--- a/ripe/atlas/tools/ipdetails.py
+++ b/ripe/atlas/tools/ipdetails.py
@@ -73,7 +73,7 @@ class IP(object):
         details = None
 
         for cache_entry in cache.keys():
-            if not cache_entry.startswith("IPDetailsPrefix:"):
+            if not cache_entry.decode().startswith("IPDetailsPrefix:"):
                 continue
 
             prefix_details = cache.get(cache_entry)

--- a/ripe/atlas/tools/renderers/traceroute_aspath.py
+++ b/ripe/atlas/tools/renderers/traceroute_aspath.py
@@ -85,7 +85,7 @@ class Renderer(BaseRenderer):
             s += "  {}: {} probe{}, {} completed\n".format(
                 as_path,
                 self.paths[as_path]['cnt'],
-                "s" if self.paths[as_path] > 1 else "",
+                "s" if self.paths[as_path]['cnt'] > 1 else "",
                 self.paths[as_path]['responded']
             )
 


### PR DESCRIPTION
So, in Python 3 `dbm`...

> Key and values are always stored as bytes.
(https://docs.python.org/3.2/library/dbm.html)

I also changed the unittest's behaviour with regards of the fake cache it uses to simulate the real one; the _poor man's fake cache_ was not able to detect issues like #164, so I thought to use a real `dbm`-based object instead of a `dict`. I introduced a new fake cache derived from the original one but that uses a temporary database, which is cleared at each `setUp()` and finally removed at `tearDownClass()` time. Don't like the idea to use temporary files too much, I struggled with that but I didn't find anything better at the moment.