### PR TITLE
A method to pass options to renderers

### DIFF
--- a/ripe/atlas/tools/cache.py
+++ b/ripe/atlas/tools/cache.py
@@ -37,7 +37,13 @@ class LocalCache(object):
 
     def __init__(self):
         self._now = datetime.datetime.now()
-        self._db = dbm.open(self._get_or_create_db_path(), "c")
+        self._db_file = None
+
+    @property
+    def _db(self):
+        if not self._db_file:
+            self._db_file = dbm.open(self._get_or_create_db_path(), "c")
+        return self._db_file
 
     def __contains__(self, key):
         return key in self._db

--- a/ripe/atlas/tools/commands/measure/base.py
+++ b/ripe/atlas/tools/commands/measure/base.py
@@ -204,6 +204,8 @@ class Command(BaseCommand):
                  "Example: --exclude-tag=system-ipv6-works"
         )
 
+        Renderer.add_arguments_for_available_renderers(self.parser)
+
     def run(self):
 
         self._account_for_selected_probes()
@@ -263,7 +265,7 @@ class Command(BaseCommand):
         self.ok("Connecting to stream...")
         try:
             Stream(capture_limit=self.arguments.probes, timeout=300).stream(
-                self.arguments.renderer, self._type, pk)
+                self.arguments.renderer, self.arguments, self._type, pk)
         except (KeyboardInterrupt, CaptureLimitExceeded):
             pass  # User said stop, so we fall through to the finally block.
         finally:

--- a/ripe/atlas/tools/commands/report.py
+++ b/ripe/atlas/tools/commands/report.py
@@ -133,6 +133,8 @@ class Command(BaseCommand):
             '(Conflicts with specifying measurement_id)',
         )
 
+        Renderer.add_arguments_for_available_renderers(self.parser)
+
     def _get_request_auth(self):
         if self.arguments.auth:
             return conf["authorisation"]["fetch_aliases"][self.arguments.auth]
@@ -187,7 +189,7 @@ class Command(BaseCommand):
 
         renderer = Renderer.get_renderer(
             self.arguments.renderer, measurement_type
-        )()
+        )(arguments=self.arguments)
 
         results = SaganSet(iterable=results, probes=self.arguments.probes)
 

--- a/ripe/atlas/tools/commands/stream.py
+++ b/ripe/atlas/tools/commands/stream.py
@@ -65,6 +65,8 @@ class Command(BaseCommand):
                  "appropriate renderer will be selected."
         )
 
+        Renderer.add_arguments_for_available_renderers(self.parser)
+
     def _get_request_auth(self):
         if self.arguments.auth:
             return conf["authorisation"]["fetch_aliases"][self.arguments.auth]
@@ -83,6 +85,7 @@ class Command(BaseCommand):
         try:
             Stream(capture_limit=self.arguments.limit).stream(
                 self.arguments.renderer,
+                self.arguments,
                 measurement.type.lower(),
                 self.arguments.measurement_id
             )

--- a/ripe/atlas/tools/ipdetails.py
+++ b/ripe/atlas/tools/ipdetails.py
@@ -73,7 +73,7 @@ class IP(object):
         details = None
 
         for cache_entry in cache.keys():
-            if not cache_entry.startswith("IPDetailsPrefix:"):
+            if not cache_entry.decode().startswith("IPDetailsPrefix:"):
                 continue
 
             prefix_details = cache.get(cache_entry)

--- a/ripe/atlas/tools/renderers/base.py
+++ b/ripe/atlas/tools/renderers/base.py
@@ -36,6 +36,11 @@ class Renderer(object):
     SHOW_DEFAULT_FOOTER = True
 
     def __init__(self, *args, **kwargs):
+        """
+        If "arguments" is in kwargs it can be used to gather renderer's
+        optional arguments which have been passed via CLI.
+        See also add_arguments().
+        """
         pass
 
     @staticmethod
@@ -55,6 +60,12 @@ class Renderer(object):
         r.remove("base")
 
         return r
+
+    @staticmethod
+    def add_arguments_for_available_renderers(parser):
+        for renderer_name in Renderer.get_available():
+            renderer_cls = Renderer.get_renderer_by_name(renderer_name)
+            renderer_cls.add_arguments(parser)
 
     @staticmethod
     def render(template, **kwargs):
@@ -124,6 +135,22 @@ class Renderer(object):
             importlib.import_module("{}.{}".format(package, name)),
             "Renderer"
         )
+
+    @staticmethod
+    def add_arguments(parser):
+        """
+        Add renderer's optional arguments here.
+
+        Suggested format:
+
+        group = parser.add_argument_group(
+            title="Optional arguments for XXX renderer"
+        )
+        group.add_argument(
+            ...
+        )
+        """
+        pass
 
     def header(self):
         """

--- a/ripe/atlas/tools/renderers/traceroute_aspath.py
+++ b/ripe/atlas/tools/renderers/traceroute_aspath.py
@@ -21,15 +21,32 @@ class Renderer(BaseRenderer):
 
     RENDERS = [BaseRenderer.TYPE_TRACEROUTE]
 
+    DEFAULT_RADIUS = 2
+
+    @staticmethod
+    def add_arguments(parser):
+        group = parser.add_argument_group(
+            title="Optional arguments for traceroute_aspath renderer"
+        )
+        group.add_argument(
+            "--traceroute-aspath-radius",
+            type=int,
+            help="Number of different ASs starting from the end of the "
+                 "traceroute path. "
+                 "Default: {}.".format(Renderer.DEFAULT_RADIUS),
+            metavar="RADIUS",
+            default=Renderer.DEFAULT_RADIUS
+        )
+
     def __init__(self, *args, **kwargs):
         BaseRenderer.__init__(self, *args, **kwargs)
         self.paths = {}
 
         # Number of different ASs starting from the end of the traceroute path.
-        #
-        # TODO: if a method to pass options to renderers will be defined
-        # this could be set by user input.
-        self.RADIUS = 2
+        if "arguments" in kwargs:
+            self.RADIUS = kwargs["arguments"].traceroute_aspath_radius
+        else:
+            self.RADIUS = Renderer.DEFAULT_RADIUS
 
     @staticmethod
     def _get_asns_for_output(asns, radius):

--- a/ripe/atlas/tools/renderers/traceroute_aspath.py
+++ b/ripe/atlas/tools/renderers/traceroute_aspath.py
@@ -85,7 +85,7 @@ class Renderer(BaseRenderer):
             s += "  {}: {} probe{}, {} completed\n".format(
                 as_path,
                 self.paths[as_path]['cnt'],
-                "s" if self.paths[as_path] > 1 else "",
+                "s" if self.paths[as_path]['cnt'] > 1 else "",
                 self.paths[as_path]['responded']
             )
 

--- a/ripe/atlas/tools/streaming.py
+++ b/ripe/atlas/tools/streaming.py
@@ -36,9 +36,11 @@ class Stream(object):
 
         self.timeout = timeout
 
-    def stream(self, renderer_name, kind, pk):
+    def stream(self, renderer_name, arguments, kind, pk):
 
-        renderer = Renderer.get_renderer(name=renderer_name, kind=kind)()
+        renderer = Renderer.get_renderer(name=renderer_name, kind=kind)(
+            arguments=arguments
+        )
 
         def on_result_response(result, *args):
             sys.stdout.write(renderer.on_result(Result.get(

--- a/tests/commands/report.py
+++ b/tests/commands/report.py
@@ -107,6 +107,30 @@ class TestReportCommand(unittest.TestCase):
                     cmd.init_args(["--renderer", choice, "1"])
                     cmd.run()
 
+    def test_arg_renderer_traceroute_aspath_with_valid_radius_arg(self):
+        """User passed arg --traceroute-aspath-radius to traceroute_aspath renderer"""
+        # Mock AtlasRequest to fail run fast and test args validity.
+        path = 'ripe.atlas.cousteau.AtlasRequest.get'
+        with mock.patch(path) as mock_get:
+            mock_get.return_value = False, {}
+            with self.assertRaises(RipeAtlasToolsException):
+                cmd = Command()
+                cmd.init_args(["--renderer", "traceroute_aspath",
+                               "--traceroute-aspath-radius", "3",
+                               "1"])
+                cmd.run()
+
+    def test_arg_renderer_traceroute_aspath_with_invalid_radius_arg(self):
+        """User passed arg --traceroute-aspath-radius to traceroute_aspath renderer with invalid value"""
+        # Mock AtlasRequest to fail run fast and test args validity.
+        with capture_sys_output():
+            with self.assertRaises(SystemExit):
+                cmd = Command()
+                cmd.init_args(["--renderer", "traceroute_aspath",
+                               "--traceroute-aspath-radius", "blaaaaa",
+                               "1"])
+                cmd.run()
+
     def test_arg_aggregate_with_valid_choice(self):
         """User passed arg aggregate with valid type."""
         # Mock AtlasRequest to fail run fast and test args validity.

--- a/tests/renderers/traceroute_aspath.py
+++ b/tests/renderers/traceroute_aspath.py
@@ -1,0 +1,60 @@
+# Copyright (c) 2015 RIPE NCC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from argparse import Namespace
+import json
+import unittest
+
+from ripe.atlas.sagan import Result
+from ripe.atlas.tools.renderers.traceroute_aspath import Renderer
+
+
+class TestTracerouteASPathRenderer(unittest.TestCase):
+
+    def __init__(self, *args, **kwargs):
+        unittest.TestCase.__init__(self, *args, **kwargs)
+        self.results = json.loads('[{"af":4,"dst_addr":"194.0.25.10","dst_name":"194.0.25.10","endtime":1457447366,"from":"24.130.240.251","fw":4730,"group_id":3606560,"lts":115,"msm_id":3606560,"msm_name":"Traceroute","prb_id":12185,"proto":"ICMP","result":[{"hop":1,"result":[{"from":"192.168.2.254","rtt":0.527,"size":76,"ttl":64},{"from":"192.168.2.254","rtt":0.373,"size":76,"ttl":64},{"from":"192.168.2.254","rtt":0.325,"size":76,"ttl":64}]},{"hop":2,"result":[{"from":"96.120.89.13","ittl":0,"rtt":8.723,"size":28,"ttl":63},{"from":"96.120.89.13","ittl":0,"rtt":8.74,"size":28,"ttl":63},{"from":"96.120.89.13","ittl":0,"rtt":8.899,"size":28,"ttl":63}]},{"hop":3,"result":[{"from":"68.87.198.29","rtt":9.573,"size":68,"ttl":253},{"from":"68.87.198.29","rtt":8.938,"size":68,"ttl":253},{"from":"68.87.198.29","rtt":10.441,"size":68,"ttl":253}]},{"hop":4,"result":[{"from":"162.151.79.133","rtt":10.924,"size":68,"ttl":252},{"from":"162.151.79.133","rtt":11.039,"size":68,"ttl":252},{"from":"162.151.79.133","rtt":11.313,"size":68,"ttl":252}]},{"hop":5,"result":[{"from":"68.85.154.93","rtt":12.945,"size":68,"ttl":251},{"from":"68.85.154.93","rtt":11.193,"size":68,"ttl":251},{"from":"68.85.154.93","rtt":11.968,"size":68,"ttl":251}]},{"hop":6,"result":[{"from":"4.68.127.109","rtt":11.842,"size":76,"ttl":59},{"from":"4.68.127.109","rtt":12.573,"size":76,"ttl":59},{"from":"4.68.127.109","rtt":19.752,"size":76,"ttl":59}]},{"hop":7,"result":[{"from":"4.69.144.143","rtt":19.838,"size":28,"ttl":245},{"from":"4.69.144.143","rtt":19.709,"size":28,"ttl":245},{"from":"4.69.144.143","rtt":19.818,"size":28,"ttl":245}]},{"hop":8,"result":[{"from":"4.69.144.143","rtt":19.703,"size":28,"ttl":245},{"from":"4.69.144.143","rtt":20.591,"size":28,"ttl":245},{"from":"4.69.144.143","rtt":18.912,"size":28,"ttl":245}]},{"hop":9,"result":[{"from":"64.215.81.146","rtt":19.955,"size":28,"ttl":245},{"from":"64.215.81.146","rtt":19.629,"size":28,"ttl":245},{"from":"64.215.81.146","rtt":20.386,"size":28,"ttl":245}]},{"hop":10,"result":[{"from":"202.147.51.46","rtt":21.059,"size":28,"ttl":245},{"from":"202.147.51.46","rtt":24.6,"size":28,"ttl":245},{"from":"202.147.51.46","rtt":26.703,"size":28,"ttl":245}]},{"hop":11,"result":[{"from":"194.0.25.10","rtt":21.819,"size":48,"ttl":54},{"from":"194.0.25.10","rtt":20.215,"size":48,"ttl":54},{"from":"194.0.25.10","rtt":19.047,"size":48,"ttl":54}]}],"size":48,"src_addr":"192.168.2.91","timestamp":1457447365,"type":"traceroute"},{"af":4,"dst_addr":"194.0.25.10","dst_name":"194.0.25.10","endtime":1457447366,"from":"204.14.101.2","fw":4730,"group_id":3606560,"lts":25,"msm_id":3606560,"msm_name":"Traceroute","prb_id":22880,"proto":"ICMP","result":[{"hop":1,"result":[{"from":"192.168.1.1","rtt":0.824,"size":76,"ttl":64},{"from":"192.168.1.1","rtt":0.406,"size":76,"ttl":64},{"from":"192.168.1.1","rtt":0.359,"size":76,"ttl":64}]},{"hop":2,"result":[{"from":"192.168.2.254","rtt":0.547,"size":28,"ttl":63},{"from":"192.168.2.254","rtt":0.451,"size":28,"ttl":63},{"from":"192.168.2.254","rtt":0.454,"size":28,"ttl":63}]},{"hop":3,"result":[{"from":"10.32.128.1","rtt":12.876,"size":28,"ttl":253},{"from":"10.32.128.1","rtt":9.85,"size":28,"ttl":253},{"from":"10.32.128.1","rtt":9.656,"size":28,"ttl":253}]},{"hop":4,"result":[{"from":"10.32.255.1","rtt":10.112,"size":28,"ttl":61},{"from":"10.32.255.1","rtt":8.231,"size":28,"ttl":61},{"from":"10.32.255.1","rtt":14.477,"size":28,"ttl":61}]},{"hop":5,"result":[{"from":"204.14.96.221","rtt":11.434,"size":28,"ttl":251},{"from":"204.14.96.221","rtt":9.149,"size":28,"ttl":251},{"from":"204.14.96.221","rtt":11.625,"size":28,"ttl":251}]},{"hop":6,"result":[{"from":"204.106.235.2","rtt":11.714,"size":28,"ttl":250},{"from":"204.106.235.2","rtt":13.193,"size":28,"ttl":250},{"from":"204.106.235.2","rtt":16.916,"size":28,"ttl":250}]},{"hop":7,"result":[{"from":"206.81.80.40","rtt":15.283,"size":28,"ttl":58},{"from":"206.81.80.40","rtt":28.69,"size":28,"ttl":58},{"from":"206.81.80.40","rtt":27.795,"size":28,"ttl":58}]},{"hop":8,"result":[{"from":"72.52.92.157","rtt":33.901,"size":28,"ttl":57},{"from":"72.52.92.157","rtt":41.775,"size":28,"ttl":57},{"from":"72.52.92.157","rtt":38.496,"size":28,"ttl":57}]},{"hop":9,"result":[{"from":"216.218.192.234","rtt":31.631,"size":68,"ttl":238},{"from":"216.218.192.234","rtt":30.064,"size":68,"ttl":238},{"from":"216.218.192.234","rtt":29.304,"size":68,"ttl":238}]},{"hop":10,"result":[{"from":"202.147.61.206","rtt":40.974,"size":68,"ttl":238},{"from":"202.147.61.206","rtt":39.599,"size":68,"ttl":238},{"from":"202.147.61.206","rtt":40.409,"size":68,"ttl":238}]},{"hop":11,"result":[{"from":"202.147.58.142","rtt":41.353,"size":28,"ttl":238},{"from":"202.147.58.142","rtt":40.937,"size":28,"ttl":238},{"from":"202.147.58.142","rtt":39.937,"size":28,"ttl":238}]},{"hop":12,"result":[{"from":"202.147.51.46","rtt":41.58,"size":28,"ttl":237},{"from":"202.147.51.46","rtt":45.443,"size":28,"ttl":237},{"from":"202.147.51.46","rtt":41.242,"size":28,"ttl":237}]},{"hop":13,"result":[{"from":"194.0.25.10","rtt":41.256,"size":48,"ttl":45},{"from":"194.0.25.10","rtt":40.092,"size":48,"ttl":45},{"from":"194.0.25.10","rtt":40.657,"size":48,"ttl":45}]}],"size":48,"src_addr":"192.168.1.4","timestamp":1457447365,"type":"traceroute"}]')
+
+    def run_renderer(self, traceroute_aspath_radius=2):
+        args = Namespace(traceroute_aspath_radius=traceroute_aspath_radius)
+        renderer = Renderer(arguments=args)
+        output = ""
+        for res in self.results:
+            output += renderer.on_result(Result.get(res))
+        output += renderer.additional(None)
+        return output
+
+    def test_basic(self):
+        output = self.run_renderer()
+        expected = """Probe #12185:  AS10026   AS1921, completed
+Probe #22880:  AS10026   AS1921, completed
+
+Number of probes for each AS path:
+
+   AS10026   AS1921: 2 probes, 2 completed
+"""
+        self.assertEqual(output, expected)
+
+    def test_arg_radius(self):
+        output = self.run_renderer(traceroute_aspath_radius=4)
+        expected = """Probe #12185:   AS3356   AS3549  AS10026   AS1921, completed
+Probe #22880:  AS26088   AS6939  AS10026   AS1921, completed
+
+Number of probes for each AS path:
+
+   AS26088   AS6939  AS10026   AS1921: 1 probe, 1 completed
+    AS3356   AS3549  AS10026   AS1921: 1 probe, 1 completed
+"""
+        self.assertEqual(output, expected)


### PR DESCRIPTION
In order to allow Renderers to add their own custom arguments to the main `argparse` and to receive optional user-provided parameters I've introduced a new method, `add_arguments()`. Everywhere the `--renderer` argument is provided the `Renderer.add_arguments_for_available_renderers()` method is called too: it cycles through all the `Renderer` classes and calls their `add_arguments()` method.
When the renderer is instantiated its `__init__()` is provided with the full `argparse.parse_args()` results, so that it can read its own optional arguments.
This new internal feature can be used to fix #155 for example (see the `--traceroute-aspath-radius` argument).