### PR TITLE
Fix/gentoo tests

### DIFF
--- a/ripe/atlas/tools/cache.py
+++ b/ripe/atlas/tools/cache.py
@@ -13,19 +13,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import datetime
+import functools
+import os
+import sys
+
 try:
     import cPickle as pickle
 except ImportError:
     import pickle
 
-import datetime
 try:
     import anydbm as dbm  # anydbm py2.7 will use the best available dbm
 except ImportError:
     import dbm  # ... and on Python3 dbm does the same
-import functools
-import os
-import sys
 
 
 class LocalCache(object):


### PR DESCRIPTION
I tried to run the test suite today in an effort to address #163 and kept running into "Resource temporarily unavailable" errors coming from the `test_ipdetails.py` file.  After some research and a lot of tinkering, I figured it out and here's the fix.

The changes to cache.py are just for cleaning up the imports so they're nicer :-)

Also, I should mention that I tried using [pytest](https://pytest.org/) with this project and it's SO much better than nose.  You should try it!  Just do:

```bash
$ pip install pytest pytest-sugar
$ python setup.py test
```

You can thank me later :-)