### PR TITLE
Measurement aliases (#172)

### DIFF
--- a/ripe/atlas/tools/commands/alias.py
+++ b/ripe/atlas/tools/commands/alias.py
@@ -17,7 +17,7 @@ import os
 
 from ..exceptions import RipeAtlasToolsException
 from ..helpers.validators import ArgumentType
-from ..settings import Aliases, aliases
+from ..settings import AliasesDB, aliases
 from .base import Command as BaseCommand
 
 
@@ -29,7 +29,7 @@ class Command(BaseCommand):
     DESCRIPTION = "Manage measurements' and probes' aliases"
     EXTRA_DESCRIPTION = (
         "As an alternative to this command, you can just create/edit {}"
-        .format(Aliases.USER_RC)
+        .format(AliasesDB.USER_RC)
     )
 
     def add_arguments(self):
@@ -40,75 +40,75 @@ class Command(BaseCommand):
                  "Run 'ripe-atlas alias <action> --help' for more details."
         )
 
-        parser = subparsers.add_parser(
+        add_parser = subparsers.add_parser(
             "add",
             help="Add/modify an alias."
         )
-        parser.add_argument(
+        add_parser.add_argument(
             "type",
             action="store",
             choices=["measurement", "probe"],
             help="Type of target object.",
         )
-        parser.add_argument(
+        add_parser.add_argument(
             "target",
             action="store",
             type=int,
             help="Target's ID.",
         )
-        parser.add_argument(
+        add_parser.add_argument(
             "alias",
             action="store",
             type=ArgumentType.alias_is_valid,
             help="Alias name.",
         )
 
-        parser = subparsers.add_parser(
+        del_parser = subparsers.add_parser(
             "del",
             help="Remove an alias."
         )
-        parser.add_argument(
+        del_parser.add_argument(
             "type",
             action="store",
             choices=["measurement", "probe"],
             help="Type of target object.",
         )
-        parser.add_argument(
+        del_parser.add_argument(
             "alias",
             action="store",
             type=ArgumentType.alias_is_valid,
             help="Alias name.",
         )
 
-        parser = subparsers.add_parser(
+        show_parser = subparsers.add_parser(
             "show",
             help="Show target's ID."
         )
-        parser.add_argument(
+        show_parser.add_argument(
             "type",
             action="store",
             choices=["measurement", "probe"],
             help="Type of target object.",
         )
-        parser.add_argument(
+        show_parser.add_argument(
             "alias",
             action="store",
             type=ArgumentType.alias_is_valid,
             help="Alias name.",
         )
 
-        parser = subparsers.add_parser(
+        list_parser = subparsers.add_parser(
             "list",
             help="List configured aliases."
         )
-        parser.add_argument(
+        list_parser.add_argument(
             "type",
             action="store",
             choices=["measurement", "probe"],
             help="Type of target object.",
         )
 
-        parser = subparsers.add_parser(
+        editor_parser = subparsers.add_parser(
             "editor",
             help="Invoke {0} to edit the configuration directly".format(
                 self.EDITOR)
@@ -121,9 +121,9 @@ class Command(BaseCommand):
                 "Action not given. Use --help for more information.")
 
         if self.arguments.action == "editor":
-            os.system("{0} {1}".format(self.EDITOR, Aliases.USER_RC))
+            os.system("{0} {1}".format(self.EDITOR, AliasesDB.USER_RC))
             return self.ok(
-                "Aliases file writen to {}".format(Aliases.USER_RC))
+                "Aliases file writen to {}".format(AliasesDB.USER_RC))
 
         else:
             alias_type = self.arguments.type
@@ -138,12 +138,12 @@ class Command(BaseCommand):
                     raise RipeAtlasToolsException(str(e))
 
                 aliases[alias_type][alias_name] = target_id
-                Aliases.write(aliases)
+                AliasesDB.write(aliases)
 
             elif self.arguments.action == "del":
                 alias_name = self.arguments.alias
                 del aliases[alias_type][alias_name]
-                Aliases.write(aliases)
+                AliasesDB.write(aliases)
 
             elif self.arguments.action == "show":
                 alias_name = self.arguments.alias
@@ -155,7 +155,7 @@ class Command(BaseCommand):
                         )
                     )
                 else:
-                    self.ko(
+                    self.not_ok(
                         "'{}' alias does not exist".format(
                             alias_name
                         )

--- a/ripe/atlas/tools/commands/alias.py
+++ b/ripe/atlas/tools/commands/alias.py
@@ -116,8 +116,6 @@ class Command(BaseCommand):
 
     def run(self):
 
-        self._create_if_necessary()
-
         if not self.arguments.action:
             raise RipeAtlasToolsException(
                 "Action not given. Use --help for more information.")
@@ -170,14 +168,3 @@ class Command(BaseCommand):
                         alias_name, aliases[alias_type][alias_name]
                     )
                 self.ok(res)
-
-    @staticmethod
-    def _create_if_necessary():
-
-        if os.path.exists(Aliases.USER_RC):
-            return
-
-        if not os.path.exists(Aliases.USER_CONFIG_DIR):
-            os.makedirs(Aliases.USER_CONFIG_DIR)
-
-        Aliases.write(aliases)

--- a/ripe/atlas/tools/commands/alias.py
+++ b/ripe/atlas/tools/commands/alias.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2016 RIPE NCC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from ..exceptions import RipeAtlasToolsException
+from ..helpers.validators import ArgumentType
+from ..settings import Aliases, aliases
+from .base import Command as BaseCommand
+
+
+class Command(BaseCommand):
+
+    NAME = "alias"
+
+    EDITOR = os.environ.get("EDITOR", "/usr/bin/vim")
+    DESCRIPTION = "Manage measurements' and probes' aliases"
+    EXTRA_DESCRIPTION = (
+        "As an alternative to this command, you can just create/edit {}"
+        .format(Aliases.USER_RC)
+    )
+
+    def add_arguments(self):
+        subparsers = self.parser.add_subparsers(
+            title="action",
+            dest="action",
+            help="Action to be performed on aliases. "
+                 "Run 'ripe-atlas alias <action> --help' for more details."
+        )
+
+        parser = subparsers.add_parser(
+            "add",
+            help="Add/modify an alias."
+        )
+        parser.add_argument(
+            "type",
+            action="store",
+            choices=["measurement", "probe"],
+            help="Type of target object.",
+        )
+        parser.add_argument(
+            "target",
+            action="store",
+            type=int,
+            help="Target's ID.",
+        )
+        parser.add_argument(
+            "alias",
+            action="store",
+            type=ArgumentType.alias_is_valid,
+            help="Alias name.",
+        )
+
+        parser = subparsers.add_parser(
+            "del",
+            help="Remove an alias."
+        )
+        parser.add_argument(
+            "type",
+            action="store",
+            choices=["measurement", "probe"],
+            help="Type of target object.",
+        )
+        parser.add_argument(
+            "alias",
+            action="store",
+            type=ArgumentType.alias_is_valid,
+            help="Alias name.",
+        )
+
+        parser = subparsers.add_parser(
+            "show",
+            help="Show target's ID."
+        )
+        parser.add_argument(
+            "type",
+            action="store",
+            choices=["measurement", "probe"],
+            help="Type of target object.",
+        )
+        parser.add_argument(
+            "alias",
+            action="store",
+            type=ArgumentType.alias_is_valid,
+            help="Alias name.",
+        )
+
+        parser = subparsers.add_parser(
+            "list",
+            help="List configured aliases."
+        )
+        parser.add_argument(
+            "type",
+            action="store",
+            choices=["measurement", "probe"],
+            help="Type of target object.",
+        )
+
+        parser = subparsers.add_parser(
+            "editor",
+            help="Invoke {0} to edit the configuration directly".format(
+                self.EDITOR)
+        )
+
+    def run(self):
+
+        self._create_if_necessary()
+
+        if not self.arguments.action:
+            raise RipeAtlasToolsException(
+                "Action not given. Use --help for more information.")
+
+        if self.arguments.action == "editor":
+            os.system("{0} {1}".format(self.EDITOR, Aliases.USER_RC))
+            return self.ok(
+                "Aliases file writen to {}".format(Aliases.USER_RC))
+
+        else:
+            alias_type = self.arguments.type
+
+            if self.arguments.action == "add":
+                alias_name = self.arguments.alias
+                target_id = self.arguments.target
+
+                try:
+                    ArgumentType.alias_is_valid(alias_name)
+                except Exception as e:
+                    raise RipeAtlasToolsException(str(e))
+
+                aliases[alias_type][alias_name] = target_id
+                Aliases.write(aliases)
+
+            elif self.arguments.action == "del":
+                alias_name = self.arguments.alias
+                del aliases[alias_type][alias_name]
+                Aliases.write(aliases)
+
+            elif self.arguments.action == "show":
+                alias_name = self.arguments.alias
+                if alias_name in aliases[alias_type]:
+                    self.ok(
+                        "'{}' is an alias for {}".format(
+                            alias_name,
+                            aliases[alias_type][alias_name]
+                        )
+                    )
+                else:
+                    self.ko(
+                        "'{}' alias does not exist".format(
+                            alias_name
+                        )
+                    )
+
+            elif self.arguments.action == "list":
+                res = "{} aliases:\n\n".format(alias_type.capitalize())
+                for alias_name in sorted(aliases[alias_type]):
+                    res += "- {}: {}\n".format(
+                        alias_name, aliases[alias_type][alias_name]
+                    )
+                self.ok(res)
+
+    @staticmethod
+    def _create_if_necessary():
+
+        if os.path.exists(Aliases.USER_RC):
+            return
+
+        if not os.path.exists(Aliases.USER_CONFIG_DIR):
+            os.makedirs(Aliases.USER_CONFIG_DIR)
+
+        Aliases.write(aliases)

--- a/ripe/atlas/tools/commands/alias.py
+++ b/ripe/atlas/tools/commands/alias.py
@@ -108,7 +108,7 @@ class Command(BaseCommand):
             help="Type of target object.",
         )
 
-        editor_parser = subparsers.add_parser(
+        subparsers.add_parser(
             "editor",
             help="Invoke {0} to edit the configuration directly".format(
                 self.EDITOR)

--- a/ripe/atlas/tools/commands/base.py
+++ b/ripe/atlas/tools/commands/base.py
@@ -200,6 +200,10 @@ class Command(object):
         if sys.stdout.isatty():
             sys.stdout.write("\n{}\n\n".format(colourise(message, "green")))
 
+    def ko(self, message):
+        if sys.stdout.isatty():
+            sys.stdout.write("\n{}\n\n".format(colourise(message, "red")))
+
     @staticmethod
     def _get_user_agent():
         """

--- a/ripe/atlas/tools/commands/base.py
+++ b/ripe/atlas/tools/commands/base.py
@@ -200,7 +200,7 @@ class Command(object):
         if sys.stdout.isatty():
             sys.stdout.write("\n{}\n\n".format(colourise(message, "green")))
 
-    def ko(self, message):
+    def not_ok(self, message):
         if sys.stdout.isatty():
             sys.stdout.write("\n{}\n\n".format(colourise(message, "red")))
 

--- a/ripe/atlas/tools/commands/configure.py
+++ b/ripe/atlas/tools/commands/configure.py
@@ -17,7 +17,6 @@ import functools
 import os
 
 from ..exceptions import RipeAtlasToolsException
-from ..helpers.validators import ArgumentType
 from ..settings import Configuration, conf
 from .base import Command as BaseCommand
 
@@ -95,32 +94,6 @@ class Command(BaseCommand):
                 conf['authorisation']['fetch_aliases'][alias] = None
 
             required_type = str
-
-        elif path[:2] == ['measurement', 'alias']:
-            if len(path) > 3:
-                raise RipeAtlasToolsException(
-                    'Invalid alias for a measurement ID: it must be in the '
-                    'format measurement.alias.some-alias=MEASUREMENT_ID')
-
-            if 'measurement' not in conf:
-                conf['measurement'] = {}
-            if 'alias' not in conf['measurement']:
-                conf['measurement']['alias'] = {}
-            if conf['measurement']['alias'] is None:
-                conf['measurement']['alias'] = {}
-
-            alias = path[2]
-
-            try:
-                ArgumentType.msm_id_or_name.alias_is_valid(alias)
-            except Exception as e:
-                raise RipeAtlasToolsException(str(e))
-
-            if alias not in conf['measurement']['alias']:
-                conf['measurement']['alias'][alias] = None
-
-            required_type = int
-
         else:
             try:
                 required_type = type(self._get_from_dict(conf, path))

--- a/ripe/atlas/tools/commands/configure.py
+++ b/ripe/atlas/tools/commands/configure.py
@@ -17,6 +17,7 @@ import functools
 import os
 
 from ..exceptions import RipeAtlasToolsException
+from ..helpers.validators import ArgumentType
 from ..settings import Configuration, conf
 from .base import Command as BaseCommand
 
@@ -94,6 +95,32 @@ class Command(BaseCommand):
                 conf['authorisation']['fetch_aliases'][alias] = None
 
             required_type = str
+
+        elif path[:2] == ['measurement', 'alias']:
+            if len(path) > 3:
+                raise RipeAtlasToolsException(
+                    'Invalid alias for a measurement ID: it must be in the '
+                    'format measurement.alias.some-alias=MEASUREMENT_ID')
+
+            if 'measurement' not in conf:
+                conf['measurement'] = {}
+            if 'alias' not in conf['measurement']:
+                conf['measurement']['alias'] = {}
+            if conf['measurement']['alias'] is None:
+                conf['measurement']['alias'] = {}
+
+            alias = path[2]
+
+            try:
+                ArgumentType.msm_id_or_name.alias_is_valid(alias)
+            except Exception as e:
+                raise RipeAtlasToolsException(str(e))
+
+            if alias not in conf['measurement']['alias']:
+                conf['measurement']['alias'][alias] = None
+
+            required_type = int
+
         else:
             try:
                 required_type = type(self._get_from_dict(conf, path))

--- a/ripe/atlas/tools/commands/go.py
+++ b/ripe/atlas/tools/commands/go.py
@@ -15,6 +15,7 @@
 
 import webbrowser
 from .base import Command as BaseCommand
+from ..helpers.validators import ArgumentType
 
 
 class Command(BaseCommand):
@@ -27,8 +28,8 @@ class Command(BaseCommand):
     def add_arguments(self):
         self.parser.add_argument(
             "measurement_id",
-            type=int,
-            help="The measurement id you want reported"
+            type=ArgumentType.msm_id_or_name(),
+            help="The measurement id or alias you want reported"
         )
 
     def run(self):

--- a/ripe/atlas/tools/commands/measure/base.py
+++ b/ripe/atlas/tools/commands/measure/base.py
@@ -26,7 +26,7 @@ from ...exceptions import RipeAtlasToolsException
 from ...helpers.colours import colourise
 from ...helpers.validators import ArgumentType
 from ...renderers import Renderer
-from ...settings import conf
+from ...settings import conf, Configuration
 from ...streaming import Stream, CaptureLimitExceeded
 from ..base import Command as BaseCommand
 
@@ -122,6 +122,12 @@ class Command(BaseCommand):
             help="Don't wait for a response from the measurement, just return "
                  "the URL at which you can later get information about the "
                  "measurement."
+        )
+        self.parser.add_argument(
+            "--set-alias",
+            help="After creating the measurement, register an alias for it.",
+            type=ArgumentType.msm_id_or_name.alias_is_valid,
+            metavar="ALIAS"
         )
 
         self.parser.add_argument(
@@ -223,6 +229,11 @@ class Command(BaseCommand):
             "Looking good!  Your measurement was created and details about "
             "it can be found here:\n\n  {0}".format(url)
         )
+
+        if self.arguments.set_alias:
+            alias = self.arguments.set_alias
+            conf["measurement"]["alias"][alias] = pk
+            Configuration.write(conf)
 
         if not self.arguments.no_report:
             self.stream(pk, url)

--- a/ripe/atlas/tools/commands/measure/base.py
+++ b/ripe/atlas/tools/commands/measure/base.py
@@ -26,7 +26,7 @@ from ...exceptions import RipeAtlasToolsException
 from ...helpers.colours import colourise
 from ...helpers.validators import ArgumentType
 from ...renderers import Renderer
-from ...settings import conf, aliases, Aliases
+from ...settings import conf, aliases, AliasesDB
 from ...streaming import Stream, CaptureLimitExceeded
 from ..base import Command as BaseCommand
 
@@ -233,7 +233,7 @@ class Command(BaseCommand):
         if self.arguments.set_alias:
             alias = self.arguments.set_alias
             aliases["measurement"][alias] = pk
-            Aliases.write(aliases)
+            AliasesDB.write(aliases)
 
         if not self.arguments.no_report:
             self.stream(pk, url)

--- a/ripe/atlas/tools/commands/measure/base.py
+++ b/ripe/atlas/tools/commands/measure/base.py
@@ -26,7 +26,7 @@ from ...exceptions import RipeAtlasToolsException
 from ...helpers.colours import colourise
 from ...helpers.validators import ArgumentType
 from ...renderers import Renderer
-from ...settings import conf, Configuration
+from ...settings import conf, aliases, Aliases
 from ...streaming import Stream, CaptureLimitExceeded
 from ..base import Command as BaseCommand
 
@@ -126,7 +126,7 @@ class Command(BaseCommand):
         self.parser.add_argument(
             "--set-alias",
             help="After creating the measurement, register an alias for it.",
-            type=ArgumentType.msm_id_or_name.alias_is_valid,
+            type=ArgumentType.alias_is_valid,
             metavar="ALIAS"
         )
 
@@ -232,8 +232,8 @@ class Command(BaseCommand):
 
         if self.arguments.set_alias:
             alias = self.arguments.set_alias
-            conf["measurement"]["alias"][alias] = pk
-            Configuration.write(conf)
+            aliases["measurement"][alias] = pk
+            Aliases.write(aliases)
 
         if not self.arguments.no_report:
             self.stream(pk, url)

--- a/ripe/atlas/tools/commands/measurement_info.py
+++ b/ripe/atlas/tools/commands/measurement_info.py
@@ -22,6 +22,7 @@ from .base import Command as BaseCommand, MetaDataMixin
 from ..exceptions import RipeAtlasToolsException
 from ..helpers.colours import colourise
 from ..helpers.sanitisers import sanitise
+from ..helpers.validators import ArgumentType
 
 
 class Command(MetaDataMixin, BaseCommand):
@@ -32,7 +33,8 @@ class Command(MetaDataMixin, BaseCommand):
     )
 
     def add_arguments(self):
-        self.parser.add_argument("id", type=int, help="The measurement id")
+        self.parser.add_argument("id", type=ArgumentType.msm_id_or_name(),
+                                 help="The measurement id or alias")
 
     def run(self):
 

--- a/ripe/atlas/tools/commands/probe_info.py
+++ b/ripe/atlas/tools/commands/probe_info.py
@@ -22,6 +22,7 @@ from .base import Command as BaseCommand, MetaDataMixin
 from ..exceptions import RipeAtlasToolsException
 from ..helpers.colours import colourise
 from ..helpers.sanitisers import sanitise
+from ..helpers.validators import ArgumentType
 
 
 class Command(MetaDataMixin, BaseCommand):
@@ -30,7 +31,8 @@ class Command(MetaDataMixin, BaseCommand):
     DESCRIPTION = "Return the meta data for one probe"
 
     def add_arguments(self):
-        self.parser.add_argument("id", type=int, help="The probe id")
+        self.parser.add_argument("id", type=ArgumentType.probe_id_or_name(),
+                                 help="The probe id or alias")
 
     def run(self):
 

--- a/ripe/atlas/tools/commands/report.py
+++ b/ripe/atlas/tools/commands/report.py
@@ -69,8 +69,8 @@ class Command(BaseCommand):
     def add_arguments(self):
         self.parser.add_argument(
             "measurement_id",
-            type=int,
-            help="The measurement ID to fetch from the results API. "
+            type=ArgumentType.msm_id_or_name(),
+            help="The measurement ID or alias to fetch from the results API. "
             "(Conflicts with the --from-file option)",
             nargs="?",
         )

--- a/ripe/atlas/tools/commands/stream.py
+++ b/ripe/atlas/tools/commands/stream.py
@@ -23,6 +23,7 @@ from ..renderers import Renderer
 from ..streaming import Stream, CaptureLimitExceeded
 from .base import Command as BaseCommand
 from ..settings import conf
+from ..helpers.validators import ArgumentType
 
 
 class Command(BaseCommand):
@@ -39,8 +40,8 @@ class Command(BaseCommand):
     def add_arguments(self):
         self.parser.add_argument(
             "measurement_id",
-            type=int,
-            help="The measurement id you want streamed"
+            type=ArgumentType.msm_id_or_name(),
+            help="The measurement id or alias you want streamed"
         )
         self.parser.add_argument(
             "--auth",

--- a/ripe/atlas/tools/helpers/validators.py
+++ b/ripe/atlas/tools/helpers/validators.py
@@ -22,6 +22,8 @@ import sys
 
 from dateutil import parser
 
+from ..settings import conf
+
 
 class ArgumentType(object):
 
@@ -177,3 +179,40 @@ class ArgumentType(object):
                     '"{}" does not appear to be valid.'.format(string))
 
             return string
+
+    class msm_id_or_name(object):
+
+        @staticmethod
+        def alias_is_valid(string):
+            ret = None
+
+            if string and not string.isdigit():
+                pattern = re.compile("^[a-z_\-0-9]+$")
+
+                if pattern.match(string):
+                    ret = string
+
+            if not ret:
+                raise argparse.ArgumentTypeError(
+                    '"{}" does not appear to be a valid '
+                    'measurement alias.'.format(string))
+
+            return ret
+
+        def __init__(self):
+            self.aliases = {}
+            if 'measurement' in conf:
+                if 'alias' in conf['measurement']:
+                    self.aliases = conf['measurement']['alias']
+
+        def __call__(self, string):
+            if string.isdigit():
+                return int(string)
+
+            if string in self.aliases:
+                return int(self.aliases[string])
+            else:
+                raise argparse.ArgumentTypeError(
+                    '"{}" does not appear to be an existent '
+                    'measurement alias.'.format(string)
+                )

--- a/ripe/atlas/tools/settings/__init__.py
+++ b/ripe/atlas/tools/settings/__init__.py
@@ -36,9 +36,6 @@ class Configuration(object):
             "fetch_aliases": {},
             "create": "",
         },
-        "measurement": {
-            "alias": {}
-        },
         "specification": {
             "af": 4,
             "description": "",
@@ -244,4 +241,28 @@ class Configuration(object):
             rc.write(payload)
 
 
+class Aliases(Configuration):
+    """
+    A singleton class to manage user aliases
+    """
+
+    USER_RC = os.path.join(Configuration.USER_CONFIG_DIR, "aliases")
+
+    DEFAULT = {
+        "measurement": {},
+        "probe": {}
+    }
+
+    @staticmethod
+    def write(aliases):
+        payload = yaml.dump(
+            aliases,
+            default_flow_style=False
+        )
+
+        with open(Aliases.USER_RC, "w") as rc:
+            rc.write(payload)
+
+
 conf = Configuration().get()
+aliases = Aliases().get()

--- a/ripe/atlas/tools/settings/__init__.py
+++ b/ripe/atlas/tools/settings/__init__.py
@@ -36,6 +36,9 @@ class Configuration(object):
             "fetch_aliases": {},
             "create": "",
         },
+        "measurement": {
+            "alias": {}
+        },
         "specification": {
             "af": 4,
             "description": "",

--- a/ripe/atlas/tools/settings/__init__.py
+++ b/ripe/atlas/tools/settings/__init__.py
@@ -255,6 +255,9 @@ class Aliases(Configuration):
 
     @staticmethod
     def write(aliases):
+        if not os.path.exists(Aliases.USER_CONFIG_DIR):
+            os.makedirs(Aliases.USER_CONFIG_DIR)
+
         payload = yaml.dump(
             aliases,
             default_flow_style=False

--- a/tests/commands/alias.py
+++ b/tests/commands/alias.py
@@ -24,9 +24,16 @@ except ImportError:
 
 from ripe.atlas.tools.commands.alias import Command
 from ripe.atlas.tools.exceptions import RipeAtlasToolsException
+from ripe.atlas.tools.settings import Aliases
 
 from ..base import capture_sys_output
 
+
+class FakeAliases(Aliases):
+
+    @staticmethod
+    def write(aliases):
+        pass
 
 class TestAliasCommand(unittest.TestCase):
 
@@ -39,10 +46,15 @@ class TestAliasCommand(unittest.TestCase):
             "prb1": 1
         }
     }
+    ALIASES_CLASS_PATH = "ripe.atlas.tools.commands.alias.Aliases"
 
     def setUp(self):
         self.cmd = Command()
         self.aliases = copy.deepcopy(TestAliasCommand.ALIASES)
+        mock.patch(self.ALIASES_CLASS_PATH, FakeAliases).start()
+
+    def tearDown(self):
+        mock.patch.stopall()
 
     def test_no_arguments(self):
         with capture_sys_output():

--- a/tests/commands/alias.py
+++ b/tests/commands/alias.py
@@ -1,0 +1,162 @@
+# Copyright (c) 2015 RIPE NCC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import copy
+import unittest
+
+# Python 3.4+ comes with mock in unittest
+try:
+    from unittest import mock
+except ImportError:
+    import mock
+
+from ripe.atlas.tools.commands.alias import Command
+from ripe.atlas.tools.exceptions import RipeAtlasToolsException
+
+from ..base import capture_sys_output
+
+
+class TestAliasCommand(unittest.TestCase):
+
+    ALIASES_PATH = "ripe.atlas.tools.commands.alias.aliases"
+    ALIASES = {
+        "measurement": {
+            "msm1": 1
+        },
+        "probe": {
+            "prb1": 1
+        }
+    }
+
+    def setUp(self):
+        self.cmd = Command()
+        self.aliases = copy.deepcopy(TestAliasCommand.ALIASES)
+
+    def test_no_arguments(self):
+        with capture_sys_output():
+            with self.assertRaises(RipeAtlasToolsException) as e:
+                self.cmd.init_args([])
+                self.cmd.run()
+            self.assertTrue(
+                str(e.exception).startswith("Action not given."))
+
+    def test_bad_action(self):
+        with capture_sys_output():
+            with self.assertRaises(SystemExit) as e:
+                self.cmd.init_args(["test"])
+
+    def test_bad_target_id(self):
+        with capture_sys_output() as (stdout, stderr):
+            with self.assertRaises(SystemExit) as e:
+                self.cmd.init_args("add probe a b".split())
+            err = stderr.getvalue().split("\n")[-2]
+        self.assertEqual(
+            err,
+            "Ripe-atlas alias add: error: argument target: invalid int value: 'a'"
+        )
+
+    def test_add_args(self):
+        for alias_type in ("probe", "measurement"):
+            with capture_sys_output() as (stdout, stderr):
+                with self.assertRaises(SystemExit) as e:
+                    cmd = Command()
+                    cmd.init_args(["add", alias_type])
+
+                with self.assertRaises(SystemExit) as e:
+                    cmd = Command()
+                    cmd.init_args(["add", alias_type, "1"])
+
+                with self.assertRaises(SystemExit) as e:
+                    cmd = Command()
+                    cmd.init_args(["add", alias_type, "1", "1"])
+
+                try:
+                    cmd = Command()
+                    cmd.init_args(["add", alias_type, "1", "one"])
+                except Exception as e:
+                    self.fail("Failed with {}".format(str(e)))
+
+    def test_del_args(self):
+        for alias_type in ("probe", "measurement"):
+            with capture_sys_output() as (stdout, stderr):
+                with self.assertRaises(SystemExit) as e:
+                    cmd = Command()
+                    cmd.init_args(["del", alias_type])
+
+                with self.assertRaises(SystemExit) as e:
+                    cmd = Command()
+                    cmd.init_args(["del", alias_type, "1"])
+
+                try:
+                    cmd = Command()
+                    cmd.init_args(["del", alias_type, "one"])
+                except Exception as e:
+                    self.fail("Failed with {}".format(str(e)))
+
+    def test_bad_alias(self):
+        with capture_sys_output() as (stdout, stderr):
+            with self.assertRaises(SystemExit) as e:
+                self.cmd.init_args("add measurement 1 bad+alias".split())
+            err = stderr.getvalue().split("\n")[-2]
+        self.assertEqual(
+            err,
+            'Ripe-atlas alias add: error: argument alias: '
+            '"bad+alias" does not appear to be a valid alias.'
+        )
+
+    def test_show_msm_ok(self):
+        path = "ripe.atlas.tools.commands.alias.Command.ok"
+        with mock.patch(path) as mock_ok:
+            with mock.patch(self.ALIASES_PATH, self.aliases):
+                self.cmd.init_args("show measurement msm1".split())
+                self.cmd.run()
+        mock_ok.assert_called_once()
+
+    def test_show_msm_ko(self):
+        path = "ripe.atlas.tools.commands.alias.Command.ko"
+        with mock.patch(path) as mock_ko:
+            with mock.patch(self.ALIASES_PATH, self.aliases):
+                self.cmd.init_args("show measurement msm2".split())
+                self.cmd.run()
+        mock_ko.assert_called_once()
+
+    def test_add_msm(self):
+        with mock.patch(self.ALIASES_PATH, self.aliases):
+            self.cmd.init_args("add measurement 2 msm2".split())
+            self.cmd.run()
+        self.assertTrue("msm2" in self.aliases["measurement"])
+        self.assertEqual(
+            self.aliases["measurement"]["msm2"],
+            2
+        )
+
+    def test_del_msm(self):
+        self.assertTrue("msm1" in self.aliases["measurement"])
+        with mock.patch(self.ALIASES_PATH, self.aliases):
+            self.cmd.init_args("del measurement msm1".split())
+            self.cmd.run()
+        self.assertFalse("msm1" in self.aliases["measurement"])
+
+    def test_list(self):
+        path = "ripe.atlas.tools.commands.alias.Command.ok"
+        with mock.patch(path) as mock_ok:
+            self.aliases["measurement"]["msm2"] = 2
+            self.aliases["measurement"]["abc"] = 123
+            with mock.patch(self.ALIASES_PATH, self.aliases):
+                self.cmd.init_args("list measurement".split())
+                self.cmd.run()
+        mock_ok.assert_called_once_with(
+            "Measurement aliases:\n\n- abc: 123\n- msm1: 1\n- msm2: 2\n"
+        )

--- a/tests/commands/alias.py
+++ b/tests/commands/alias.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015 RIPE NCC
+# Copyright (c) 2016 RIPE NCC
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -24,12 +24,12 @@ except ImportError:
 
 from ripe.atlas.tools.commands.alias import Command
 from ripe.atlas.tools.exceptions import RipeAtlasToolsException
-from ripe.atlas.tools.settings import Aliases
+from ripe.atlas.tools.settings import AliasesDB
 
 from ..base import capture_sys_output
 
 
-class FakeAliases(Aliases):
+class FakeAliasesDB(AliasesDB):
 
     @staticmethod
     def write(aliases):
@@ -46,12 +46,12 @@ class TestAliasCommand(unittest.TestCase):
             "prb1": 1
         }
     }
-    ALIASES_CLASS_PATH = "ripe.atlas.tools.commands.alias.Aliases"
+    ALIASES_CLASS_PATH = "ripe.atlas.tools.commands.alias.AliasesDB"
 
     def setUp(self):
         self.cmd = Command()
         self.aliases = copy.deepcopy(TestAliasCommand.ALIASES)
-        mock.patch(self.ALIASES_CLASS_PATH, FakeAliases).start()
+        mock.patch(self.ALIASES_CLASS_PATH, FakeAliasesDB).start()
 
     def tearDown(self):
         mock.patch.stopall()
@@ -137,7 +137,7 @@ class TestAliasCommand(unittest.TestCase):
         mock_ok.assert_called_once()
 
     def test_show_msm_ko(self):
-        path = "ripe.atlas.tools.commands.alias.Command.ko"
+        path = "ripe.atlas.tools.commands.alias.Command.not_ok"
         with mock.patch(path) as mock_ko:
             with mock.patch(self.ALIASES_PATH, self.aliases):
                 self.cmd.init_args("show measurement msm2".split())

--- a/tests/commands/loading.py
+++ b/tests/commands/loading.py
@@ -25,6 +25,7 @@ class Command(BaseCommand):
 class TestCommandLoading(unittest.TestCase):
     expected_builtins = [
         "configure",
+        "alias",
         "go",
         "measure",
         "measurement-info",

--- a/tests/commands/measure.py
+++ b/tests/commands/measure.py
@@ -36,7 +36,7 @@ from ripe.atlas.tools.commands.measure import (
     NtpMeasureCommand,
 )
 from ripe.atlas.tools.exceptions import RipeAtlasToolsException
-from ripe.atlas.tools.settings import Configuration, Aliases
+from ripe.atlas.tools.settings import Configuration, AliasesDB
 
 from ..base import capture_sys_output
 
@@ -954,12 +954,12 @@ class TestMeasureCommand(unittest.TestCase):
 
     def test_set_alias(self):
         path_aliases = "ripe.atlas.tools.commands.measure.base.aliases"
-        new_aliases = copy.deepcopy(Aliases.DEFAULT)
+        new_aliases = copy.deepcopy(AliasesDB.DEFAULT)
 
         with mock.patch(path_aliases, new_aliases):
-            path_Aliases = "ripe.atlas.tools.commands.measure.base.Aliases"
-            with mock.patch(path_Aliases, autospec=True) as new_Aliases:
-                new_Aliases.write.return_value = True
+            path_AliasesDB = "ripe.atlas.tools.commands.measure.base.AliasesDB"
+            with mock.patch(path_AliasesDB, autospec=True) as new_AliasesDB:
+                new_AliasesDB.write.return_value = True
 
                 path_create = "ripe.atlas.tools.commands.measure.base.Command.create"
                 with mock.patch(path_create) as mock_create:

--- a/tests/commands/measure.py
+++ b/tests/commands/measure.py
@@ -957,23 +957,27 @@ class TestMeasureCommand(unittest.TestCase):
         new_aliases = copy.deepcopy(Aliases.DEFAULT)
 
         with mock.patch(path_aliases, new_aliases):
-            path_create = "ripe.atlas.tools.commands.measure.base.Command.create"
-            with mock.patch(path_create) as mock_create:
-                mock_create.return_value = (
-                    True,
-                    {"measurements": [1234]}
-                )
-                cmd = PingMeasureCommand()
-                cmd.init_args([
-                    "ping",
-                    "--target",
-                    "www.ripe.net",
-                    "--no-report",
-                    "--set-alias",
-                    "PING_RIPE"
-                ])
-                cmd.run()
-                self.assertEqual(
-                    new_aliases["measurement"]["PING_RIPE"],
-                    1234
-                )
+            path_Aliases = "ripe.atlas.tools.commands.measure.base.Aliases"
+            with mock.patch(path_Aliases, autospec=True) as new_Aliases:
+                new_Aliases.write.return_value = True
+
+                path_create = "ripe.atlas.tools.commands.measure.base.Command.create"
+                with mock.patch(path_create) as mock_create:
+                    mock_create.return_value = (
+                        True,
+                        {"measurements": [1234]}
+                    )
+                    cmd = PingMeasureCommand()
+                    cmd.init_args([
+                        "ping",
+                        "--target",
+                        "www.ripe.net",
+                        "--no-report",
+                        "--set-alias",
+                        "PING_RIPE"
+                    ])
+                    cmd.run()
+                    self.assertEqual(
+                        new_aliases["measurement"]["PING_RIPE"],
+                        1234
+                    )

--- a/tests/commands/measure.py
+++ b/tests/commands/measure.py
@@ -740,6 +740,18 @@ class TestMeasureCommand(unittest.TestCase):
             with self.assertRaises(SystemExit):
                 PingMeasureCommand().init_args([
                     "ping",
+                    "--set-alias", ".invalid"
+                ])
+            self.assertEqual(
+                stderr.getvalue().split("\n")[-2],
+                'ripe-atlas measure: error: argument --set-alias: '
+                '".invalid" does not appear to be a valid measurement alias.'
+            )
+
+        with capture_sys_output() as (stdout, stderr):
+            with self.assertRaises(SystemExit):
+                PingMeasureCommand().init_args([
+                    "ping",
                     "--renderer", "not-a-renderer"
                 ])
             self.assertTrue(stderr.getvalue().split("\n")[-2].startswith(

--- a/tests/commands/report.py
+++ b/tests/commands/report.py
@@ -28,7 +28,7 @@ from ripe.atlas.cousteau import Probe
 from ripe.atlas.tools.commands.report import Command
 from ripe.atlas.tools.exceptions import RipeAtlasToolsException
 from ripe.atlas.tools.renderers import Renderer
-from ripe.atlas.tools.settings import Configuration
+from ripe.atlas.tools.settings import Aliases
 from ripe.atlas.tools.version import __version__
 from ..base import capture_sys_output, StringIO
 
@@ -179,10 +179,10 @@ class TestReportCommand(unittest.TestCase):
 
     def test_arg_valid_msm_alias(self):
         """User passed a valid measurement alias."""
-        path_conf = "ripe.atlas.tools.helpers.validators.conf"
-        new_conf = copy.deepcopy(Configuration.DEFAULT)
-        new_conf['measurement']['alias']['UNITTEST_ALIAS'] = 1234
-        with mock.patch(path_conf, new_conf):
+        path_aliases = "ripe.atlas.tools.helpers.validators.aliases"
+        new_aliases = copy.deepcopy(Aliases.DEFAULT)
+        new_aliases['measurement']['UNITTEST_ALIAS'] = 1234
+        with mock.patch(path_aliases, new_aliases):
             path_get = 'ripe.atlas.tools.commands.report.Command._get_results_from_api'
             with mock.patch(path_get) as mock_get:
                 mock_get.side_effect = RipeAtlasToolsException

--- a/tests/commands/report.py
+++ b/tests/commands/report.py
@@ -28,7 +28,7 @@ from ripe.atlas.cousteau import Probe
 from ripe.atlas.tools.commands.report import Command
 from ripe.atlas.tools.exceptions import RipeAtlasToolsException
 from ripe.atlas.tools.renderers import Renderer
-from ripe.atlas.tools.settings import Aliases
+from ripe.atlas.tools.settings import AliasesDB
 from ripe.atlas.tools.version import __version__
 from ..base import capture_sys_output, StringIO
 
@@ -180,7 +180,7 @@ class TestReportCommand(unittest.TestCase):
     def test_arg_valid_msm_alias(self):
         """User passed a valid measurement alias."""
         path_aliases = "ripe.atlas.tools.helpers.validators.aliases"
-        new_aliases = copy.deepcopy(Aliases.DEFAULT)
+        new_aliases = copy.deepcopy(AliasesDB.DEFAULT)
         new_aliases['measurement']['UNITTEST_ALIAS'] = 1234
         with mock.patch(path_aliases, new_aliases):
             path_get = 'ripe.atlas.tools.commands.report.Command._get_results_from_api'

--- a/tests/helpers/validators.py
+++ b/tests/helpers/validators.py
@@ -136,17 +136,17 @@ class TestArgumentTypeHelper(unittest.TestCase):
 
     def test_measurement_alias(self):
 
-        tests = ["", ".invalid", "\\invalid", "+invalid",
+        tests = ["", "\\invalid", "+invalid",
                  ":invalid", "12345"]
         for test in tests:
             with self.assertRaises(argparse.ArgumentTypeError):
-                ArgumentType.msm_id_or_name.alias_is_valid(test)
+                ArgumentType.alias_is_valid(test)
 
         tests = ["valid", "123valid", "valid123", "_valid",
-                 "valid_", "-valid", "valid-"]
+                 "valid_", "-valid", "valid-", ".valid"]
 
         for test in tests:
             self.assertEqual(
-                ArgumentType.msm_id_or_name.alias_is_valid(test),
+                ArgumentType.alias_is_valid(test),
                 test
             )

--- a/tests/helpers/validators.py
+++ b/tests/helpers/validators.py
@@ -133,3 +133,20 @@ class TestArgumentTypeHelper(unittest.TestCase):
             [1, 2, 3]
         )
         os.unlink(in_file)
+
+    def test_measurement_alias(self):
+
+        tests = ["", ".invalid", "\\invalid", "+invalid",
+                 ":invalid", "12345"]
+        for test in tests:
+            with self.assertRaises(argparse.ArgumentTypeError):
+                ArgumentType.msm_id_or_name.alias_is_valid(test)
+
+        tests = ["valid", "123valid", "valid123", "_valid",
+                 "valid_", "-valid", "valid-"]
+
+        for test in tests:
+            self.assertEqual(
+                ArgumentType.msm_id_or_name.alias_is_valid(test),
+                test
+            )


### PR DESCRIPTION
I really like @danielquinn's idea (#172)!

I came up with this PR that uses the same approach already seen on #138 (API keys aliases).

It allows to add an alias while creating a new measurement:

```
$ ripe-atlas measure ping --target 8.8.8.8 --set-alias ping_google
```

Or to configure an alias for an existing one:

```
$ ripe-atlas configure --set "measurement.alias.traceroute_ripe=1674977"
```

Finally, commands can be run by passing a measurement ID or alias:

```
$ ripe-atlas report ping_google
$ ripe-atlas go traceroute_ripe
```

This is what I quickly got by tweaking the existing code without introducing/modifying core functionalities.

My solution is based on the user local configuration (`~/.config/ripe-atlas-tools/rc`), and that may be a limit (I'm thinking about teams which share the same environment).

Also, dots (".") can't be used in alias names (unless you all just close your eyes and allow me to do Very Bad Things &trade; on `configure.py` `Command.set()` and surroundings.), while they are quite commonly used on the Internet!

Lastly, this can be also improved in the way reported in #99, that is moving it from Magellan to Cousteau, but I think all this would require a deeper analysis on Magellan/Cousteau integration.