### PR TITLE
Fixed broken key in stream command by removing the key

### DIFF
--- a/ripe/atlas/tools/commands/stream.py
+++ b/ripe/atlas/tools/commands/stream.py
@@ -68,18 +68,12 @@ class Command(BaseCommand):
 
         Renderer.add_arguments_for_available_renderers(self.parser)
 
-    def _get_request_auth(self):
-        if self.arguments.auth:
-            return conf["authorisation"]["fetch_aliases"][self.arguments.auth]
-        else:
-            return conf["authorisation"]["fetch"]
-
     def run(self):
 
         try:
             measurement = Measurement(
                 id=self.arguments.measurement_id, user_agent=self.user_agent,
-                key=self._get_request_auth)
+            )
         except APIResponseError as e:
             raise RipeAtlasToolsException(e.args[0])
 

--- a/ripe/atlas/tools/commands/stream.py
+++ b/ripe/atlas/tools/commands/stream.py
@@ -22,7 +22,6 @@ from ..exceptions import RipeAtlasToolsException
 from ..renderers import Renderer
 from ..streaming import Stream, CaptureLimitExceeded
 from .base import Command as BaseCommand
-from ..settings import conf
 from ..helpers.validators import ArgumentType
 
 
@@ -43,17 +42,6 @@ class Command(BaseCommand):
             "measurement_id",
             type=ArgumentType.msm_id_or_name(),
             help="The measurement id or alias you want streamed"
-        )
-        self.parser.add_argument(
-            "--auth",
-            type=str,
-            choices=conf["authorisation"]["fetch_aliases"].keys(),
-            default=conf["authorisation"]["fetch"],
-            help="The API key alias you want to use to fetch the measurement. "
-                 "To configure an API key alias, use "
-                 "ripe-atlas configure --set authorisation.fetch_aliases."
-                 "ALIAS_NAME=YOUR_KEY"
-
         )
         self.parser.add_argument(
             "--limit",

--- a/ripe/atlas/tools/commands/stream.py
+++ b/ripe/atlas/tools/commands/stream.py
@@ -31,8 +31,9 @@ class Command(BaseCommand):
     NAME = "stream"
 
     DESCRIPTION = (
-        "Output the results of a measurement as they become available"
+        "Output the results of a public measurement as they become available"
     )
+    EXTRA_DESCRIPTION = "Streaming of non-public measurements is not supported."
     URLS = {
         "detail": "/api/v2/measurements/{0}.json",
     }


### PR DESCRIPTION
The "stream" command was inadvertently passing a string representation of a Python function as the "?key=" parameter to the measurements API. This used to be silently ignored by the API, but it was recently changed to explicitly reject malformed or non-existent keys.

Providing a "fetch" key is actually not necessary anyway in this case, because the stream service doesn't support non-public measurements so if we can't fetch the metadata then we may as well give up.