### PR TITLE
Use unicode literal in colourisation

### DIFF
--- a/ripe/atlas/tools/helpers/colours.py
+++ b/ripe/atlas/tools/helpers/colours.py
@@ -37,7 +37,7 @@ class Colour(object):
 
     @classmethod
     def _colourise(cls, text, colour):
-        return "{}[{}m{}{}[0m".format(chr(0x1b), colour, text, chr(0x1b))
+        return u"{}[{}m{}{}[0m".format(chr(0x1b), colour, text, chr(0x1b))
 
     @classmethod
     def black(cls, text):


### PR DESCRIPTION
The colourisation previously used a run-off-the-mill string for interpolation. This caused problems in Python 2.x if unicode data was to be colourized. This PR fixes that.

Cheers