### PR TITLE
Fix cache open

### DIFF
--- a/ripe/atlas/tools/cache.py
+++ b/ripe/atlas/tools/cache.py
@@ -42,7 +42,7 @@ class LocalCache(object):
 
     @property
     def _db(self):
-        if not self._db_file:
+        if self._db_file is None:
             self._db_file = dbm.open(self._get_or_create_db_path(), "c")
         return self._db_file
 


### PR DESCRIPTION
Checking with "not" seems not to work even when the cache is already initialized, causing a retry on open which is presumably not allowed by gdbm.

Fixes #177.