### PR TITLE
WIP: adapt dns measurement to v2 api

### DIFF
--- a/ripe/atlas/tools/commands/measure/dns.py
+++ b/ripe/atlas/tools/commands/measure/dns.py
@@ -139,5 +139,7 @@ class DnsMeasureCommand(Command):
         r["retry"] = self.arguments.retry
         r["udp_payload_size"] = self.arguments.udp_payload_size
         r["use_probe_resolver"] = "target" not in r
+        r["resolve_on_probe"] = "target" not in r # renamed for v2?
+        r["target"] = r["target"] if "target" in r else None # v2: expects emptyor target
 
         return r


### PR DESCRIPTION
Note, this is a rebased #180 (from a separate feature branch instead of master).

This change makes it possible to submit a "resolve on probe" query against the currently running instance of atlas api.

I will not like to get this merged as it is but just to start a discussion how this should be fixed. Current implementation doesn't provide the required "resolve_on_probe" key nor set an empty "target" for "resolve on probe" queries.

The current README.md would also need to be updated accordingly:
```
$ ripe-atlas measure dns --query-argument example.com
$ ripe-atlas measure dns --use-probe-resolver --query-type AAAA --query-argument example.com
```
to adapt with:

```--use-probe-resolver``` does not exists anymore.

Currently the user is not allowed to miss the root (".") of the query, so in this case argument should be "example.com.".

edit: unittests will also need to be adjusted.