### PR TITLE
Add a simple NTP renderer

### DIFF
--- a/ripe/atlas/tools/renderers/ntp.py
+++ b/ripe/atlas/tools/renderers/ntp.py
@@ -14,11 +14,53 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from .base import Renderer as BaseRenderer
-
+from ..helpers.colours import colourise
+from tzlocal import get_localzone
+from datetime import datetime
 
 class Renderer(BaseRenderer):
-
     RENDERS = [BaseRenderer.TYPE_NTP]
 
     def on_result(self, result, probes=None):
-        return "Not ready yet\n"
+        created = result.created.astimezone(get_localzone())
+        probe_id = result.probe_id
+        r = '\n\nProbe #{0}\n{1}\n'.format(probe_id, '=' * 79)
+        res = self.get_formatted_response(probe_id, created, result)
+        if res:
+            return r + res
+        else:
+            return colourise(r + 'No results\n', 'red')
+
+    def get_formatted_response(self, probe_id, created, result):
+        leap = result.leap_second_indicator
+        stratum = result.stratum
+        v = result.version
+        mode = result.mode
+        end_time = result.end_time
+        poll = result.poll
+        precision = result.precision
+        refid = result.reference_id
+        ref_time = result.reference_time
+        root_delay = result.root_delay
+        root_disp = result.root_dispersion
+        if not leap and not stratum and not v and not mode:
+            return
+        if mode != 'server':
+            print('invalid mode: %s' % mode)
+        r = '[NTP] %s -> %s (%s)\n' % (result.source_address, result.destination_name, result.destination_address)
+        r += '\tversion: %s, stratum: %s/16\n' % (colourise(v, 'bold'), colourise(stratum, 'bold'))
+        r += '\trefid: %s\n' % colourise(refid, 'bold')
+        r += '\tleap: %s, poll: %s, precision: %s\n' % (leap, poll, precision)
+        r += '\troot_delay: %s, root_disp: %s\n' % (root_delay, root_disp)
+        r += '\tref-time: %s\n' % datetime.fromtimestamp(ref_time)
+        try:
+            for idx, pkt in enumerate(result.packets):
+                r += '\t[%s] %s\n' % (idx, str(pkt))
+                r += '\t\ttrans: %s -> recv: %s\n' % (pkt.transmitted_time, pkt.received_time)
+                r += '\t\torigin: %s -> final: %s\n' % (pkt.origin_time, pkt.final_time)
+
+        except Exception as ex:
+            print('Got exception when reading packet: %s' % ex)
+            print('Raw: %s' % pkt.raw_data)
+
+        return r

--- a/ripe/atlas/tools/renderers/ntp.py
+++ b/ripe/atlas/tools/renderers/ntp.py
@@ -13,15 +13,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .base import Renderer as BaseRenderer
-from ..helpers.colours import colourise
 from tzlocal import get_localzone
 from datetime import datetime
+from .base import Renderer as BaseRenderer
+from ..helpers.colours import colourise
+
 
 class Renderer(BaseRenderer):
     RENDERS = [BaseRenderer.TYPE_NTP]
 
-    def on_result(self, result, probes=None):
+    def on_result(self, result):
         created = result.created.astimezone(get_localzone())
         probe_id = result.probe_id
         r = '\n\nProbe #{0}\n{1}\n'.format(probe_id, '=' * 79)
@@ -36,29 +37,38 @@ class Renderer(BaseRenderer):
         stratum = result.stratum
         v = result.version
         mode = result.mode
-        end_time = result.end_time
+        # just here for completeness, flake8 doesn't like when it's not used
+        # end_time = result.end_time
         poll = result.poll
         precision = result.precision
         refid = result.reference_id
         ref_time = result.reference_time
         root_delay = result.root_delay
         root_disp = result.root_dispersion
+
         if not leap and not stratum and not v and not mode:
             return
+
         if mode != 'server':
             print('invalid mode: %s' % mode)
-        r = '[NTP] %s -> %s (%s)\n' % (result.source_address, result.destination_name, result.destination_address)
-        r += '\tversion: %s, stratum: %s/16\n' % (colourise(v, 'bold'), colourise(stratum, 'bold'))
+
+        r = '[NTP] %s -> %s (%s)\n' % (result.source_address,
+                                       result.destination_name,
+                                       result.destination_address)
+        r += '\tversion: %s, stratum: %s/16\n' % (colourise(v, 'bold'),
+                                                  colourise(stratum, 'bold'))
         r += '\trefid: %s\n' % colourise(refid, 'bold')
         r += '\tleap: %s, poll: %s, precision: %s\n' % (leap, poll, precision)
         r += '\troot_delay: %s, root_disp: %s\n' % (root_delay, root_disp)
-        r += '\tref-time: %s\n' % datetime.fromtimestamp(ref_time)
+        r += '\tref-time: %s\n\n' % datetime.fromtimestamp(ref_time)
+
         try:
             for idx, pkt in enumerate(result.packets):
                 r += '\t[%s] %s\n' % (idx, str(pkt))
-                r += '\t\ttrans: %s -> recv: %s\n' % (pkt.transmitted_time, pkt.received_time)
-                r += '\t\torigin: %s -> final: %s\n' % (pkt.origin_time, pkt.final_time)
-
+                r += '\t\ttrans: %s -> recv: %s\n' % (pkt.transmitted_time,
+                                                      pkt.received_time)
+                r += '\t\torigin: %s -> final: %s\n\n' % (pkt.origin_time,
+                                                          pkt.final_time)
         except Exception as ex:
             print('Got exception when reading packet: %s' % ex)
             print('Raw: %s' % pkt.raw_data)


### PR DESCRIPTION
This commit adds a simple renderer for NTP responses, even when not completely thought it is probably better than nothing :-)

Example output:
```
Probe #28460
===============================================================================
[NTP] 134.169.5.13 -> 129.250.35.250 (129.250.35.250)
        version: 4, stratum: 2/16
        refid: f9e063d5
        leap: no, poll: 1, precision: 9.537e-07
        root_delay: 0, root_disp: 0.00260925
        ref-time: 2087-03-13 11:04:27.139235
        [0] 0.016|-0.287309
                trans: 2017-03-13 10:16:39.361360+00:00 -> recv: 2017-03-13 10:16:39.361338+00:00
                origin: 2017-03-13 10:16:39.066158+00:00 -> final: 2017-03-13 10:16:39.081922+00:00
        [1] 0.016|-0.28729699999999997
                trans: 2017-03-13 10:16:39.377500+00:00 -> recv: 2017-03-13 10:16:39.377489+00:00
                origin: 2017-03-13 10:16:39.082377+00:00 -> final: 2017-03-13 10:16:39.098018+00:00
        [2] 0.016|-0.287231
                trans: 2017-03-13 10:16:39.393505+00:00 -> recv: 2017-03-13 10:16:39.393474+00:00
                origin: 2017-03-13 10:16:39.098453+00:00 -> final: 2017-03-13 10:16:39.114063+00:00

```
Related to #120.