### PR TITLE
Unicode problems

### DIFF
--- a/ripe/atlas/tools/commands/base.py
+++ b/ripe/atlas/tools/commands/base.py
@@ -291,9 +291,6 @@ class MetaDataMixin(object):
 
         checkmark = u"\u2714"
         x = u"\u2718"
-        if six.PY2:
-            checkmark = checkmark.encode("utf-8")
-            x = x.encode("utf-8")
 
         if boolean:
             return colourise(checkmark, "green")
@@ -309,8 +306,12 @@ class MetaDataMixin(object):
 
     @staticmethod
     def _render_line(header, value):
-        print("{}  {}".format(
-            colourise("{:25}".format(header), "bold"), value))
+        # Make sure we don't mix unicode and strings
+        if six.PY2 and isinstance(value, six.string_types):
+            value = unicode(value)
+
+        log = u"{}  {}".format(colourise("{:25}".format(header), "bold"), value).encode("utf-8")
+        print(log)
 
 
 class Factory(object):

--- a/ripe/atlas/tools/commands/measurement_search.py
+++ b/ripe/atlas/tools/commands/measurement_search.py
@@ -147,9 +147,10 @@ class Command(TabularFieldsMixin, BaseCommand):
         print(colourise(hr, "bold"))
 
         for measurement in truncated_measurements:
-            print(colourise(self._get_line_format().format(
-                *self._get_line_items(measurement)
-            ), self._get_colour_from_status(measurement.status_id)))
+            lformat = self._get_line_format().format(*self._get_line_items(measurement))
+            lcolour = self._get_colour_from_status(measurement.status_id)
+            log = colourise(lformat, lcolour).encode("utf8")
+            print(log)
 
         print(colourise(hr, "bold"))
 

--- a/ripe/atlas/tools/commands/probe_info.py
+++ b/ripe/atlas/tools/commands/probe_info.py
@@ -72,7 +72,8 @@ class Command(MetaDataMixin, BaseCommand):
 
         print(colourise("Tags", "bold"))
         for tag in probe.tags:
-            print("  {}".format(tag["slug"]))
+            log_tag = "  {}".format(tag["slug"])
+            print(log_tag.encode("utf8"))
 
     @staticmethod
     def _prettify_coordinates(geometry):

--- a/ripe/atlas/tools/commands/probe_search.py
+++ b/ripe/atlas/tools/commands/probe_search.py
@@ -239,7 +239,7 @@ class Command(TabularFieldsMixin, BaseCommand):
         else:
 
             for probe in truncated_probes:
-                print(self._get_line(probe))
+                print(self._get_line(probe).encode("utf8"))
 
         print(colourise(hr, "bold"))
 
@@ -272,8 +272,7 @@ class Command(TabularFieldsMixin, BaseCommand):
         elif isinstance(aggregation_data, list):
 
             for index, probe in enumerate(aggregation_data):
-                print(" ", end="")
-                print(self._get_line(probe))
+                print(" {}".format(self._get_line(probe)).encode("utf8"))
                 if self.arguments.max_per_aggregation:
                     if index >= self.arguments.max_per_aggregation - 1:
                         break
@@ -511,23 +510,15 @@ class Command(TabularFieldsMixin, BaseCommand):
 
     def _get_line(self, probe):
         """
-        Python 2 and 3 differ on how to render strings with non-ascii characters
-        in them, so we have to accommodate both here.
+        Returns a utf8 encode string safe for printing and outputing
+        to files.
         """
-
-        if six.PY2:
-
-            return colourise(
-                self._get_line_format().format(
-                    *self._get_line_items(probe)
-                ).encode("utf-8"),
-                self._get_colour_from_status(probe.status)
-            )
-
-        return colourise(
+        log = colourise(
             self._get_line_format().format(*self._get_line_items(probe)),
             self._get_colour_from_status(probe.status)
         )
+
+        return log
 
     def _get_filter_key_value_pair(self, k, v):
         if k == "country_code":

--- a/ripe/atlas/tools/helpers/colours.py
+++ b/ripe/atlas/tools/helpers/colours.py
@@ -14,6 +14,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import sys
+import six
 COLOURS_AVAILABLE = False
 try:
     # We use curses to detect ANSI colour support
@@ -37,6 +38,10 @@ class Colour(object):
 
     @classmethod
     def _colourise(cls, text, colour):
+        # Make sure we don't mix unicode and strings
+        if six.PY2 and isinstance(text, six.string_types):
+            text = unicode(text)
+
         return u"{}[{}m{}{}[0m".format(chr(0x1b), colour, text, chr(0x1b))
 
     @classmethod

--- a/tests/commands/measurement_search.py
+++ b/tests/commands/measurement_search.py
@@ -95,22 +95,23 @@ class TestMeasurementsCommand(unittest.TestCase):
             cmd.init_args([])
             cmd.run()
 
-        expected_content = (
-            "\n"
-            "Id      Type       Description                                            Status\n"
-            "================================================================================\n"
-            "1       ping       Description 1                                         Ongoing\n"
-            "2       ping       Description 2                                         Ongoing\n"
-            "3       ping       Description 3                                         Ongoing\n"
-            "4       ping       Description 4                                         Ongoing\n"
-            "5       ping       Description 5                                         Ongoing\n"
-            "================================================================================\n"
-            "                                               Showing 5 of 5 total measurements\n"
-            "\n"
-        )
+        expected_content = [
+            "",
+            "Id      Type       Description                                            Status",
+            "================================================================================",
+            str(b"1       ping       Description 1                                         Ongoing"),
+            str(b"2       ping       Description 2                                         Ongoing"),
+            str(b"3       ping       Description 3                                         Ongoing"),
+            str(b"4       ping       Description 4                                         Ongoing"),
+            str(b"5       ping       Description 5                                         Ongoing"),
+            "================================================================================",
+            "                                               Showing 5 of 5 total measurements",
+            "",
+        ]
+        self.maxDiff = None
         self.assertEqual(
             set(stdout.getvalue().split("\n")),
-            set(expected_content.split("\n"))
+            set(expected_content)
         )
         self.assertEqual(
             cmd.arguments.field, ("id", "type", "description", "status"))

--- a/tests/commands/probe_search.py
+++ b/tests/commands/probe_search.py
@@ -404,23 +404,23 @@ class TestProbesCommand(unittest.TestCase):
             with mock.patch(path) as mock_get:
                 mock_get.return_value = FakeGen()
                 cmd.run()
-                expected_output = (
-                    "\n"
-                    "Filters:\n"
-                    "  Country: GR\n"
-                    "\n"
-                    "ID    Asn_v4 Asn_v6 Country Status         \n"
-                    "===========================================\n"
-                    "1     3333            gr    None           \n"
-                    "2     3333            de    None           \n"
-                    "3     3332            de    None           \n"
-                    "4     3333            nl    None           \n"
-                    "5     3333            gr    None           \n"
-                    "===========================================\n"
-                    "                Showing 4 of 4 total probes\n"
-                    "\n"
-                )
-                self.assertEquals(stdout.getvalue(), expected_output)
+                expected_output = [
+                    "",
+                    "Filters:",
+                    "  Country: GR",
+                    "",
+                    "ID    Asn_v4 Asn_v6 Country Status         ",
+                    "===========================================",
+                    str(b"1     3333            gr    None           "),
+                    str(b"2     3333            de    None           "),
+                    str(b"3     3332            de    None           "),
+                    str(b"4     3333            nl    None           "),
+                    str(b"5     3333            gr    None           "),
+                    "===========================================",
+                    "                Showing 4 of 4 total probes",
+                    "",
+                ]
+                self.assertEquals(set(stdout.getvalue().split("\n")), set(expected_output))
 
     def test_render_without_aggregation_with_limit(self):
         """Tests rendering of results without aggregation but with limit"""
@@ -435,20 +435,21 @@ class TestProbesCommand(unittest.TestCase):
             with mock.patch(path) as mock_get:
                 mock_get.return_value = FakeGen()
                 cmd.run()
-                expected_output = (
-                    "\n"
-                    "Filters:\n"
-                    "  Country: GR\n"
-                    "\n"
-                    "ID    Asn_v4 Asn_v6 Country Status         \n"
-                    "===========================================\n"
-                    "1     3333            gr    None           \n"
-                    "2     3333            de    None           \n"
-                    "===========================================\n"
-                    "                Showing 2 of 4 total probes\n"
-                    "\n"
-                )
-                self.assertEquals(stdout.getvalue(), expected_output)
+                self.maxDiff = None
+                expected_output = [
+                    "",
+                    "Filters:",
+                    "  Country: GR",
+                    "",
+                    "ID    Asn_v4 Asn_v6 Country Status         ",
+                    "===========================================",
+                    str(b"1     3333            gr    None           "),
+                    str(b"2     3333            de    None           "),
+                    "===========================================",
+                    "                Showing 2 of 4 total probes",
+                    ""
+                ]
+                self.assertEquals(set(stdout.getvalue().split("\n")), set(expected_output))
 
     def test_render_with_aggregation(self):
         """Tests rendering of results with aggregation"""
@@ -465,37 +466,39 @@ class TestProbesCommand(unittest.TestCase):
             with mock.patch(path) as mock_get:
                 mock_get.return_value = FakeGen()
                 cmd.run()
-                expected_blob = (
-                    "\n"
-                    "Filters:\n"
-                    "  Country: GR\n"
-                    "\n"
-                    "   ID    Asn_v4 Asn_v6 Country Status         \n"
-                    "==============================================\n"
-                    "Country: DE\n"
-                    " ASN_V4: 3332\n"
-                    "  PREFIX_V4: 193.0/22\n"
-                    "   3     3332            de    None           \n"
-                    " ASN_V4: 3333\n"
-                    "  PREFIX_V4: 193.0/22\n"
-                    "   2     3333            de    None           \n"
-                    "\n"
-                    "Country: GR\n"
-                    " ASN_V4: 3333\n"
-                    "  PREFIX_V4: 193.0/22\n"
-                    "   1     3333            gr    None           \n"
-                    "   5     3333            gr    None           \n"
-                    "\n"
-                    "Country: NL\n"
-                    " ASN_V4: 3333\n"
-                    "  PREFIX_V4: 193.0/22\n"
-                    "   4     3333            nl    None           \n"
-                    "==============================================\n"
-                    "                   Showing 4 of 4 total probes\n"
-                    "\n"
-                )
-                expected_set = set(expected_blob.split("\n"))
-                returned_set = set(stdout.getvalue().split("\n"))
+                expected_blob = [
+                    "",
+                    "Filters:",
+                    "  Country: GR",
+                    "",
+                    "   ID    Asn_v4 Asn_v6 Country Status         ",
+                    "==============================================",
+                    "Country: DE",
+                    " ASN_V4: 3332",
+                    "  PREFIX_V4: 193.0/22",
+                    str(b"   3     3332            de    None           "),
+                    " ASN_V4: 3333",
+                    "  PREFIX_V4: 193.0/22",
+                    str(b"   2     3333            de    None           "),
+                    "",
+                    "Country: GR",
+                    " ASN_V4: 3333",
+                    "  PREFIX_V4: 193.0/22",
+                    str(b"   1     3333            gr    None           "),
+                    str(b"   5     3333            gr    None           "),
+                    "",
+                    "Country: NL",
+                    " ASN_V4: 3333",
+                    "  PREFIX_V4: 193.0/22",
+                    str(b"   4     3333            nl    None           "),
+                    "==============================================",
+                    "                   Showing 4 of 4 total probes",
+                    ""
+                ]
+                self.maxDiff = None
+                out = stdout.getvalue()
+                expected_set = set(expected_blob)
+                returned_set = set(out.split("\n"))
                 self.assertEquals(returned_set, expected_set)
 
     def test_render_with_aggregation_with_limit(self):
@@ -514,22 +517,22 @@ class TestProbesCommand(unittest.TestCase):
             with mock.patch(path) as mock_get:
                 mock_get.return_value = FakeGen()
                 cmd.run()
-                expected_output = (
-                    "\n"
-                    "Filters:\n"
-                    "  Country: GR\n"
-                    "\n"
-                    "   ID    Asn_v4 Asn_v6 Country Status         \n"
-                    "==============================================\n"
-                    "Country: GR\n"
-                    " ASN_V4: 3333\n"
-                    "  PREFIX_V4: 193.0/22\n"
-                    "   1     3333            gr    None           \n"
-                    "==============================================\n"
-                    "                   Showing 1 of 4 total probes\n"
-                    "\n"
-                )
-                expected_set = set(expected_output.split("\n"))
+                expected_output = [
+                    "",
+                    "Filters:",
+                    "  Country: GR",
+                    "",
+                    "   ID    Asn_v4 Asn_v6 Country Status         ",
+                    "==============================================",
+                    "Country: GR",
+                    " ASN_V4: 3333",
+                    "  PREFIX_V4: 193.0/22",
+                    str(b"   1     3333            gr    None           "),
+                    "==============================================",
+                    "                   Showing 1 of 4 total probes",
+                    "",
+                ]
+                expected_set = set(expected_output)
                 returned_set = set(stdout.getvalue().split("\n"))
                 self.assertEquals(returned_set, expected_set)
 
@@ -551,34 +554,34 @@ class TestProbesCommand(unittest.TestCase):
             with mock.patch(path) as mock_get:
                 mock_get.return_value = FakeGen()
                 cmd.run()
-                expected_output = (
-                    "\n"
-                    "Filters:\n  "
-                    "Country: GR\n"
-                    "\n"
-                    "   ID    Asn_v4 Asn_v6 Country Status         \n"
-                    "==============================================\n"
-                    "Country: DE\n"
-                    " ASN_V4: 3332\n"
-                    "  PREFIX_V4: 193.0/22\n"
-                    "   3     3332            de    None           \n"
-                    " ASN_V4: 3333\n"
-                    "  PREFIX_V4: 193.0/22\n"
-                    "   2     3333            de    None           \n"
-                    "\n"
-                    "Country: GR\n"
-                    " ASN_V4: 3333\n"
-                    "  PREFIX_V4: 193.0/22\n"
-                    "   1     3333            gr    None           \n"
-                    "\n"
-                    "Country: NL\n"
-                    " ASN_V4: 3333\n"
-                    "  PREFIX_V4: 193.0/22\n"
-                    "   4     3333            nl    None           \n"
-                    "==============================================\n"
-                    "                   Showing 4 of 4 total probes\n"
-                    "\n"
-                )
-                expected_set = set(expected_output.split("\n"))
+                expected_output = [
+                    "",
+                    "Filters:",
+                    "  Country: GR",
+                    "",
+                    "   ID    Asn_v4 Asn_v6 Country Status         ",
+                    "==============================================",
+                    "Country: DE",
+                    " ASN_V4: 3332",
+                    "  PREFIX_V4: 193.0/22",
+                    str(b"   3     3332            de    None           "),
+                    " ASN_V4: 3333",
+                    "  PREFIX_V4: 193.0/22",
+                    str(b"   2     3333            de    None           "),
+                    "",
+                    "Country: GR",
+                    " ASN_V4: 3333",
+                    "  PREFIX_V4: 193.0/22",
+                    str(b"   1     3333            gr    None           "),
+                    "",
+                    "Country: NL",
+                    " ASN_V4: 3333",
+                    "  PREFIX_V4: 193.0/22",
+                    str(b"   4     3333            nl    None           "),
+                    "==============================================",
+                    "                   Showing 4 of 4 total probes",
+                    "",
+                ]
+                expected_set = set(expected_output)
                 returned_set = set(stdout.getvalue().split("\n"))
                 self.assertEquals(returned_set, expected_set)


### PR DESCRIPTION
PR #179 caused some mixing of unicode and strings. Commands like "ripe-atlas measurement-info 5001" start breaking. This commit tries to make they way we treat prints and output to file safer. That means we try to use unicode everywhere and as soon as we print we transform to byte strings with utf8 encoding. This way outputing to file is safe (it used to break before).
To be honest the best and cleanest would be to use a custom wrapper for print and make all logs byte strings before printing. This way printing to shell and redirecting to file would be safe.
For now it seems to fix the issues we had but if we discover more we should go for the general solution.