### PR TITLE
Allow "tcp ping" for traceroute measurements

### DIFF
--- a/ripe/atlas/tools/commands/measure/traceroute.py
+++ b/ripe/atlas/tools/commands/measure/traceroute.py
@@ -48,7 +48,7 @@ class TracerouteMeasureCommand(Command):
         )
         specific.add_argument(
             "--size",
-            type=ArgumentType.integer_range(minimum=1),
+            type=ArgumentType.integer_range(minimum=0),
             default=spec["size"],
             help="The size of packets sent"
         )

--- a/tests/commands/measure.py
+++ b/tests/commands/measure.py
@@ -849,7 +849,8 @@ class TestMeasureCommand(unittest.TestCase):
                 ),
                 1
             ),
-            "size": ((PingMeasureCommand, TracerouteMeasureCommand), 1),
+            "size": ((PingMeasureCommand,), 1),
+            "size": ((TracerouteMeasureCommand,), 0),
             "packet-interval": ((PingMeasureCommand,), 1),
             "timeout": ((TracerouteMeasureCommand, NtpMeasureCommand,), 1),
             "destination-option-size": ((TracerouteMeasureCommand,), 1),


### PR DESCRIPTION
"ripe-atlas measure traceroute" imposes a minumum of size "1" to packets, but this won't allow "tcp ping" as documented in https://labs.ripe.net/Members/wilhelm/measuring-your-web-server-reachability-with-tcp-ping
I modified the minimum value to 0, adjusted the tests directory, and successfully create a tcp-ping measurement: https://atlas.ripe.net/measurements/9717581/#!general
using:
ripe-atlas measure traceroute --protocol TCP --size 0 --first-hop 64 --max-hops 64 --from-country CL --probes 10 --target www.nic.cl