### PR TITLE
Synchronize option, limits and defaults with the API

### DIFF
--- a/dev-scripts/compare-openapi-spec.py
+++ b/dev-scripts/compare-openapi-spec.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python
+"""
+Compare the CLI measure command options with the fields, limits and defaults
+from the API via a call to the OpenAPI (swagger) URL.
+"""
+from __future__ import print_function
+
+import requests
+
+from ripe.atlas.tools.commands.base import Command
+
+openapi_url = "https://atlas.ripe.net/docs/api/v2/reference/api-docs/api/v2/measurements"
+
+types = [
+    ("ping", "Writeping measurement"),
+    ("traceroute", "Writetraceroute measurement"),
+    ("dns", "WriteDNS measurement"),
+    ("sslcert", "SSL cert measurement"),
+    ("http", "HTTP measurement"),
+    ("ntp", "NTP measurement"),
+]
+
+# These are the expected differences from the OpenAPI spec.
+# If somethign is defined here it means that an option deliberately has a
+# different default, valid range or is not included in the CLI tools.
+# e.g. if we want the tools to behave more like their common unix counterparts
+# or it makes sense to express things differently on a command-line
+
+common_differences = {
+    "is_oneoff": None,  # implied by lack of --interval
+    "resolve_on_probe": None,  # implied by lack of --target
+    "type": None,  # set as the subcommand
+    "start_time": None,  # deliberately unsupported
+    "stop_time": None,  # deliberately unsupported
+    "is_public": None,  # deliberately unsupported
+
+    "description": {
+        "default": "",
+    },
+    "interval": {
+        "default": None,
+    }
+}
+
+type_expected_differences = {
+    "ping": dict(common_differences, **{
+        "packet_interval": {
+            "default": 1000,
+        },
+        "size": {
+            "default": 48,
+        },
+        "skip_dns_check": None,
+    }),
+    "traceroute": dict(common_differences, **{
+        "max_hops": {
+            "default": 255,
+        },
+        "protocol": {
+            "default": "ICMP",
+        },
+        "skip_dns_check": None,
+        "paris": {
+            "default": 0,
+        },
+        "dont_fragment": {
+            "default": False,
+        },
+        "response_timeout": {
+            "default": None,
+        }
+    }),
+    "dns": dict(common_differences, **{
+        "protocol": {
+            "default": "UDP",
+        },
+        "query_class": {
+            "default": "IN",
+        },
+        "query_type": {
+            "default": "A",
+        },
+        "skip_dns_check": None,
+        "set_rd_bit": {
+            "default": True,
+        },
+        "use_probe_resolver": None,  # Implied by missing target
+        "include_abuf": None,
+        "include_qbuf": None,
+        "prepend_probe_id": None,
+        "use_macros": None,
+    }),
+    "sslcert": common_differences.copy(),
+    "http": dict(common_differences, **{
+        "extended_timing": None,  # "timing_verbosity"
+        "more_extended_timing": None,  # "timing_verbosity"
+        "max_bytes_read": {
+            "alias": "body_bytes",
+        },
+        "path": {
+            "default": "/",
+        }
+    }),
+    "ntp": common_differences.copy(),
+}
+
+
+def compare_type(cmd_name, api_model, expected_differences):
+    print(cmd_name)
+    cmd = Command.load_command_class("measure")(["measure", cmd_name]).create()
+    cmd.add_arguments()
+
+    args = {}
+
+    for arg in cmd.parser._actions:
+        args[arg.dest] = arg
+
+    seen_diffs = False
+
+    for field_name, model_field in sorted(api_model["properties"].items()):
+        if field_name in expected_differences and expected_differences[field_name] is None:
+            continue
+        if model_field["readOnly"]:
+            continue
+
+        explicit_values = expected_differences.get(field_name, {})
+
+        opt_name = explicit_values.get("alias", field_name)
+
+        if opt_name in args:
+            cmd_field = args.get(opt_name)
+
+            expected_default = explicit_values.get("default", model_field.get("defaultValue"))
+            if cmd_field.default != expected_default:
+                print("\t", field_name, "DEFAULT", repr(cmd_field.default), repr(expected_default))
+                seen_diffs |= True
+
+            expected_min = explicit_values.get("minimum", model_field.get("minimum"))
+            cmd_min = getattr(cmd_field.type, "minimum", None)
+            if cmd_min != expected_min:
+                print("\t", field_name, "MINIMUM", cmd_min, expected_min)
+                seen_diffs |= True
+
+            expected_max = explicit_values.get("maximum", model_field.get("maximum"))
+            cmd_max = getattr(cmd_field.type, "maximum", None)
+            if cmd_max != expected_max:
+                print("\t", field_name, "MAXIMUM", cmd_max, expected_max)
+                seen_diffs |= True
+        else:
+            print("\t", field_name, "\t", "MISSING")
+            seen_diffs |= True
+
+    if not seen_diffs:
+        print("\t", "OK")
+
+
+if __name__ == "__main__":
+    api_spec = requests.get(openapi_url).json()
+
+    for cmd_name, api_name in types:
+        compare_type(
+            cmd_name,
+            api_spec["models"][api_name],
+            type_expected_differences[cmd_name]
+        )

--- a/dev-scripts/compare-openapi-spec.py
+++ b/dev-scripts/compare-openapi-spec.py
@@ -28,18 +28,17 @@ types = [
 
 common_differences = {
     "is_oneoff": None,  # implied by lack of --interval
-    "resolve_on_probe": None,  # implied by lack of --target
     "type": None,  # set as the subcommand
     "start_time": None,  # deliberately unsupported
     "stop_time": None,  # deliberately unsupported
     "is_public": None,  # deliberately unsupported
-
     "description": {
         "default": "",
     },
     "interval": {
         "default": None,
-    }
+    },
+    "resolve_on_probe": None,  # Not sent explicitly to preserve behaviour
 }
 
 type_expected_differences = {

--- a/ripe/atlas/tools/commands/measure/base.py
+++ b/ripe/atlas/tools/commands/measure/base.py
@@ -210,6 +210,21 @@ class Command(BaseCommand):
                  "Example: --exclude-tag=system-ipv6-works"
         )
 
+        self.parser.add_argument(
+            "--group-id",
+            type=int,
+            help="Add newly created measurement to a group that you own",
+        )
+
+        # Validation is too complex because it's based on the interval, so
+        # we just accept the round-trip for server-side validation
+        self.parser.add_argument(
+            "--spread",
+            type=int,
+            default=conf["specification"]["spread"],
+            help="Specify the spread of probes within a single measurement interval",
+        )
+
         Renderer.add_arguments_for_available_renderers(self.parser)
 
     def run(self):
@@ -325,6 +340,12 @@ class Command(BaseCommand):
 
         if target:
             r["target"] = target
+
+        if self.arguments.group_id:
+            r["group_id"] = self.arguments.group_id
+
+        if self.arguments.spread is not None:
+            r["spread"] = self.arguments.spread
 
         return r
 

--- a/ripe/atlas/tools/commands/measure/base.py
+++ b/ripe/atlas/tools/commands/measure/base.py
@@ -224,6 +224,12 @@ class Command(BaseCommand):
             default=conf["specification"]["spread"],
             help="Specify the spread of probes within a single measurement interval",
         )
+        self.parser.add_argument(
+            "--resolve-on-probe",
+            action="store_true",
+            default=conf["specification"]["resolve_on_probe"],
+            help="Causes the target to be resolved by each probe rather than once by the server",
+        )
 
         Renderer.add_arguments_for_available_renderers(self.parser)
 
@@ -346,6 +352,9 @@ class Command(BaseCommand):
 
         if self.arguments.spread is not None:
             r["spread"] = self.arguments.spread
+
+        if self.arguments.resolve_on_probe is not None:
+            r["resolve_on_probe"] = self.arguments.resolve_on_probe
 
         return r
 

--- a/ripe/atlas/tools/commands/measure/dns.py
+++ b/ripe/atlas/tools/commands/measure/dns.py
@@ -97,15 +97,21 @@ class DnsMeasureCommand(Command):
         )
         specific.add_argument(
             "--retry",
-            type=ArgumentType.integer_range(minimum=1),
+            type=ArgumentType.integer_range(minimum=0, maximum=10),
             default=conf["specification"]["types"]["dns"]["retry"],
             help="Number of times to retry"
         )
         specific.add_argument(
             "--udp-payload-size",
-            type=ArgumentType.integer_range(minimum=1),
+            type=ArgumentType.integer_range(minimum=512, maximum=4096),
             default=conf["specification"]["types"]["dns"]["udp-payload-size"],
             help="May be any integer between 512 and 4096 inclusive"
+        )
+        specific.add_argument(
+            "--timeout",
+            default=conf["specification"]["types"]["dns"]["timeout"],
+            type=ArgumentType.integer_range(minimum=100, maximum=30000),
+            help="Per packet timeout in milliseconds",
         )
 
     def clean_target(self):
@@ -139,5 +145,7 @@ class DnsMeasureCommand(Command):
         r["retry"] = self.arguments.retry
         r["udp_payload_size"] = self.arguments.udp_payload_size
         r["use_probe_resolver"] = "target" not in r
+        if self.arguments.timeout is not None:
+            r["timeout"] = self.arguments.timeout
 
         return r

--- a/ripe/atlas/tools/commands/measure/http.py
+++ b/ripe/atlas/tools/commands/measure/http.py
@@ -50,7 +50,7 @@ class HttpMeasureCommand(Command):
         )
         specific.add_argument(
             "--port",
-            type=ArgumentType.integer_range(minimum=1, maximum=2**16),
+            type=ArgumentType.integer_range(minimum=1, maximum=65535),
             default=spec["port"],
             help="Destination port"
         )

--- a/ripe/atlas/tools/commands/measure/ntp.py
+++ b/ripe/atlas/tools/commands/measure/ntp.py
@@ -32,13 +32,13 @@ class NtpMeasureCommand(Command):
         specific = self.parser.add_argument_group("NTP-specific Options")
         specific.add_argument(
             "--packets",
-            type=ArgumentType.integer_range(minimum=1),
+            type=ArgumentType.integer_range(minimum=1, maximum=16),
             default=spec["packets"],
             help="The number of packets sent"
         )
         specific.add_argument(
             "--timeout",
-            type=ArgumentType.integer_range(minimum=1),
+            type=ArgumentType.integer_range(minimum=1, maximum=60000),
             default=spec["timeout"],
             help="The timeout per-packet"
         )

--- a/ripe/atlas/tools/commands/measure/ping.py
+++ b/ripe/atlas/tools/commands/measure/ping.py
@@ -31,20 +31,26 @@ class PingMeasureCommand(Command):
         specific = self.parser.add_argument_group("Ping-specific Options")
         specific.add_argument(
             "--packets",
-            type=ArgumentType.integer_range(minimum=1),
+            type=ArgumentType.integer_range(minimum=1, maximum=16),
             default=spec["packets"],
             help="The number of packets sent"
         )
         specific.add_argument(
             "--size",
-            type=ArgumentType.integer_range(minimum=1),
+            type=ArgumentType.integer_range(minimum=1, maximum=2048),
             default=spec["size"],
             help="The size of packets sent"
         )
         specific.add_argument(
             "--packet-interval",
-            type=ArgumentType.integer_range(minimum=1),
+            type=ArgumentType.integer_range(minimum=2, maximum=30000),
             default=spec["packet-interval"],
+        )
+        specific.add_argument(
+            "--include-probe-id",
+            default=spec["include_probe_id"],
+            action="store_true",
+            help="Include the ASCII-encoded probe ID in the ping packets",
         )
 
     def _get_measurement_kwargs(self):
@@ -54,5 +60,7 @@ class PingMeasureCommand(Command):
         r["packets"] = self.arguments.packets
         r["packet_interval"] = self.arguments.packet_interval
         r["size"] = self.arguments.size
+        if self.arguments.include_probe_id:
+            r["include_probe_id"] = True
 
         return r

--- a/ripe/atlas/tools/commands/measure/sslcert.py
+++ b/ripe/atlas/tools/commands/measure/sslcert.py
@@ -33,14 +33,22 @@ class SslcertMeasureCommand(Command):
             "SSL Certificate-specific Options")
         specific.add_argument(
             "--port",
-            type=ArgumentType.integer_range(minimum=1, maximum=2**16),
+            type=ArgumentType.integer_range(minimum=1, maximum=65535),
             default=spec["port"],
             help="Destination port"
+        )
+        specific.add_argument(
+            "--hostname",
+            default=spec["hostname"],
+            type=str,
+            help="SNI Hostname",
         )
 
     def _get_measurement_kwargs(self):
 
         r = Command._get_measurement_kwargs(self)
         r["port"] = self.arguments.port
+        if self.arguments.hostname:
+            r["hostname"] = self.arguments.hostname
 
         return r

--- a/ripe/atlas/tools/commands/measure/traceroute.py
+++ b/ripe/atlas/tools/commands/measure/traceroute.py
@@ -112,7 +112,8 @@ class TracerouteMeasureCommand(Command):
             "--duplicate-timeout",
             default=spec["duplicate-timeout"],
             type=int,
-            help="Time to wait (in milliseconds) for a duplicate response after receiving the first response",
+            help="Time to wait (in milliseconds) for a duplicate response "
+            "after receiving the first response",
         )
         specific.add_argument(
             "--response-timeout",

--- a/ripe/atlas/tools/commands/measure/traceroute.py
+++ b/ripe/atlas/tools/commands/measure/traceroute.py
@@ -42,13 +42,13 @@ class TracerouteMeasureCommand(Command):
             "Traceroute-specific Options")
         specific.add_argument(
             "--packets",
-            type=ArgumentType.integer_range(minimum=1),
+            type=ArgumentType.integer_range(minimum=1, maximum=16),
             default=spec["packets"],
             help="The number of packets sent"
         )
         specific.add_argument(
             "--size",
-            type=ArgumentType.integer_range(minimum=0),
+            type=ArgumentType.integer_range(minimum=0, maximum=2048),
             default=spec["size"],
             help="The size of packets sent"
         )
@@ -92,21 +92,33 @@ class TracerouteMeasureCommand(Command):
         )
         specific.add_argument(
             "--port",
-            type=ArgumentType.integer_range(minimum=1, maximum=2**16),
+            type=ArgumentType.integer_range(minimum=1, maximum=65535),
             default=spec["port"],
             help="Destination port, valid for TCP only"
         )
         specific.add_argument(
             "--destination-option-size",
-            type=ArgumentType.integer_range(minimum=1),
+            type=ArgumentType.integer_range(minimum=0, maximum=1024),
             default=spec["destination-option-size"],
             help="IPv6 destination option header"
         )
         specific.add_argument(
             "--hop-by-hop-option-size",
-            type=ArgumentType.integer_range(minimum=1),
+            type=ArgumentType.integer_range(minimum=0, maximum=2048),
             default=spec["hop-by-hop-option-size"],
             help=" IPv6 hop by hop option header"
+        )
+        specific.add_argument(
+            "--duplicate-timeout",
+            default=spec["duplicate-timeout"],
+            type=int,
+            help="Time to wait (in milliseconds) for a duplicate response after receiving the first response",
+        )
+        specific.add_argument(
+            "--response-timeout",
+            default=spec["response-timeout"],
+            type=ArgumentType.integer_range(minimum=1, maximum=60000),
+            help="Response timeout for one packet",
         )
 
     def _get_measurement_kwargs(self):
@@ -120,5 +132,12 @@ class TracerouteMeasureCommand(Command):
         )
         for key in keys:
             r[key] = getattr(self.arguments, key)
+        optional_keys = [
+            "duplicate_timeout", "response_timeout"
+        ]
+        for key in optional_keys:
+            val = getattr(self.arguments, key)
+            if val is not None:
+                r[key] = val
 
         return r

--- a/ripe/atlas/tools/settings/__init__.py
+++ b/ripe/atlas/tools/settings/__init__.py
@@ -78,6 +78,7 @@ class Configuration(UserSettingsParser):
                 "requested": 50,
             },
             "spread": None,
+            "resolve_on_probe": None,
             "times": {
                 "one-off": True,
                 "interval": None,

--- a/ripe/atlas/tools/settings/__init__.py
+++ b/ripe/atlas/tools/settings/__init__.py
@@ -77,6 +77,7 @@ class Configuration(UserSettingsParser):
                 "value": "WW",
                 "requested": 50,
             },
+            "spread": None,
             "times": {
                 "one-off": True,
                 "interval": None,
@@ -87,7 +88,8 @@ class Configuration(UserSettingsParser):
                 "ping": {
                     "packets": 3,
                     "packet-interval": 1000,
-                    "size": 48
+                    "size": 48,
+                    "include_probe_id": None,
                 },
                 "traceroute": {
                     "packets": 3,
@@ -100,10 +102,13 @@ class Configuration(UserSettingsParser):
                     "port": 80,
                     "destination-option-size": None,
                     "hop-by-hop-option-size": None,
-                    "timeout": 4000
+                    "timeout": 4000,
+                    "response-timeout": None,
+                    "duplicate-timeout": None,
                 },
                 "sslcert": {
-                    "port": 443
+                    "port": 443,
+                    "hostname": None,
                 },
                 "ntp": {
                     "packets": 3,
@@ -119,7 +124,8 @@ class Configuration(UserSettingsParser):
                     "set-nsid-bit": False,
                     "udp-payload-size": 512,
                     "set-rd-bit": True,
-                    "retry": 0
+                    "retry": 0,
+                    "timeout": None,
                 },
                 "http": {
                     "header-bytes": 0,
@@ -128,7 +134,7 @@ class Configuration(UserSettingsParser):
                     "port": 80,
                     "path": "/",
                     "query-string": None,
-                    "user-agent": "RIPE ATLAS: https://atlas.ripe.net/",
+                    "user-agent": "RIPE Atlas: https://atlas.ripe.net/",
                     "body-bytes": None,
                     "timing-verbosity": 0,
                 },

--- a/tests/commands/loading.py
+++ b/tests/commands/loading.py
@@ -62,6 +62,12 @@ class TestCommandLoading(unittest.TestCase):
     def test_command_loading(self, _get_user_command_path):
         _get_user_command_path.return_value = self.user_command_path
 
+        # For some reason the command classes are initialized in some envs
+        # but not in others at this point
+        if Command._commands:
+            Command._commands.clear()
+        Command._load_commands()
+
         available_commands = Command.get_available_commands()
 
         # Check that we have the command list that we expect

--- a/tests/commands/measure.py
+++ b/tests/commands/measure.py
@@ -188,6 +188,7 @@ class TestMeasureCommand(unittest.TestCase):
             "--group-id", "1000001",
             "--include-probe-id",
             "--spread", "60",
+            "--resolve-on-probe",
         ])
         self.assertEqual(
             cmd._get_measurement_kwargs(),
@@ -201,6 +202,7 @@ class TestMeasureCommand(unittest.TestCase):
                 "group_id": 1000001,
                 "include_probe_id": True,
                 "spread": 60,
+                "resolve_on_probe": True,
             }
         )
 

--- a/tests/commands/measure.py
+++ b/tests/commands/measure.py
@@ -184,7 +184,10 @@ class TestMeasureCommand(unittest.TestCase):
             "--description", "This is my description",
             "--packets", "7",
             "--packet-interval", "200",
-            "--size", "24"
+            "--size", "24",
+            "--group-id", "1000001",
+            "--include-probe-id",
+            "--spread", "60",
         ])
         self.assertEqual(
             cmd._get_measurement_kwargs(),
@@ -194,7 +197,10 @@ class TestMeasureCommand(unittest.TestCase):
                 "target": "ripe.net",
                 "packets": 7,
                 "packet_interval": 200,
-                "size": 24
+                "size": 24,
+                "group_id": 1000001,
+                "include_probe_id": True,
+                "spread": 60,
             }
         )
 
@@ -243,7 +249,9 @@ class TestMeasureCommand(unittest.TestCase):
             "--paris", "8",
             "--port", "123",
             "--protocol", "TCP",
-            "--timeout", "1500"
+            "--timeout", "1500",
+            "--duplicate-timeout", "500",
+            "--response-timeout", "500",
         ])
         self.assertEqual(
             cmd._get_measurement_kwargs(),
@@ -261,7 +269,9 @@ class TestMeasureCommand(unittest.TestCase):
                 "paris": 8,
                 "port": 123,
                 "protocol": "TCP",
-                "timeout": 1500
+                "timeout": 1500,
+                "duplicate_timeout": 500,
+                "response_timeout": 500,
             }
         )
 
@@ -333,7 +343,8 @@ class TestMeasureCommand(unittest.TestCase):
             "--set-nsid-bit",
             "--protocol", "TCP",
             "--retry", "2",
-            "--udp-payload-size", "5"
+            "--udp-payload-size", "512",
+            "--timeout", "500",
         ])
         self.assertEqual(
             cmd._get_measurement_kwargs(),
@@ -350,8 +361,9 @@ class TestMeasureCommand(unittest.TestCase):
                 "set_nsid_bit": True,
                 "protocol": "TCP",
                 "retry": 2,
-                "udp_payload_size": 5,
-                "use_probe_resolver": False
+                "udp_payload_size": 512,
+                "use_probe_resolver": False,
+                "timeout": 500,
             }
         )
 
@@ -406,7 +418,7 @@ class TestMeasureCommand(unittest.TestCase):
         """Testing for query type in lower case"""
         cmd = DnsMeasureCommand()
         cmd.init_args([
-            "dns", "--query-argument", "ripe.net", "--query-type", "txt"
+            "dns", "--query-argument", "ripe.net", "--query-type", "txt",
         ])
         self.assertEqual(
             cmd._get_measurement_kwargs(),
@@ -452,7 +464,8 @@ class TestMeasureCommand(unittest.TestCase):
             "--target", "ripe.net",
             "--af", "6",
             "--description", "This is my description",
-            "--port", "7"
+            "--port", "7",
+            "--hostname", "ripe.net",
         ])
         self.assertEqual(
             cmd._get_measurement_kwargs(),
@@ -460,7 +473,8 @@ class TestMeasureCommand(unittest.TestCase):
                 "af": 6,
                 "description": "This is my description",
                 "target": "ripe.net",
-                "port": 7
+                "port": 7,
+                "hostname": "ripe.net",
             }
         )
 
@@ -561,7 +575,7 @@ class TestMeasureCommand(unittest.TestCase):
                 "description": "This is my description",
                 "target": "ripe.net",
                 "packets": 6,
-                "timeout": 9000
+                "timeout": 9000,
             }
         )
 
@@ -838,27 +852,12 @@ class TestMeasureCommand(unittest.TestCase):
                 "invalid choice: 3 (choose from 0, 1, 2)"
             )
 
-        min_options = {
-            "from-measurement": ((PingMeasureCommand,), 1),
-            "probes": ((PingMeasureCommand,), 1),
-            "packets": (
-                (
-                    PingMeasureCommand,
-                    TracerouteMeasureCommand,
-                    NtpMeasureCommand
-                ),
-                1
-            ),
-            "size": ((PingMeasureCommand,), 1),
-            "size": ((TracerouteMeasureCommand,), 0),
-            "packet-interval": ((PingMeasureCommand,), 1),
-            "timeout": ((TracerouteMeasureCommand, NtpMeasureCommand,), 1),
-            "destination-option-size": ((TracerouteMeasureCommand,), 1),
-            "hop-by-hop-option-size": ((TracerouteMeasureCommand,), 1),
-            "retry": ((DnsMeasureCommand,), 1),
-            "udp-payload-size": ((DnsMeasureCommand,), 1),
-        }
-        for option, (klasses, minimum) in min_options.items():
+        min_options = [
+            ("from-measurement", ((PingMeasureCommand,), 1)),
+            ("probes", ((PingMeasureCommand,), 1)),
+            ("timeout", ((TracerouteMeasureCommand,), 1)),
+        ]
+        for option, (klasses, minimum) in min_options:
             for klass in klasses:
                 with capture_sys_output() as (stdout, stderr):
                     test_value = minimum - 1
@@ -876,48 +875,70 @@ class TestMeasureCommand(unittest.TestCase):
                         )
                     )
 
-        min_max_options = {
-            "from-asn": (
+        min_max_options = [
+            ("from-asn", (
                 (PingMeasureCommand,),
-                (0, 2 ** 32 - 2 + 1)
-            ),
-            "paris": (
+                (1, 2 ** 32 - 2)
+            )),
+            ("paris", (
                 (TracerouteMeasureCommand,),
-                (-1, 65)
-            ),
-            "first-hop": (
+                (0, 64)
+            )),
+            ("first-hop", (
                 (TracerouteMeasureCommand,),
-                (0, 256)
-            ),
-            "max-hops": (
+                (1, 255)
+            )),
+            ("max-hops", (
                 (TracerouteMeasureCommand,),
-                (0, 256)
-            ),
-            "port": (
+                (1, 255)
+            )),
+            ("port", (
                 (
                     TracerouteMeasureCommand,
                     SslcertMeasureCommand,
                     HttpMeasureCommand
                 ),
-                (0, 2 ** 16 + 1)
-            ),
-            "header-bytes": ((HttpMeasureCommand,), (-1, 2049)),
-            "body-bytes": ((HttpMeasureCommand,), (0, 1020049)),
-        }
-        for option, (klasses, extremes) in min_max_options.items():
+                (1, 65535)
+            )),
+            ("header-bytes", ((HttpMeasureCommand,), (0, 2048))),
+            ("body-bytes", ((HttpMeasureCommand,), (1, 1020048))),
+            ("size", ((PingMeasureCommand,), (1, 2048))),
+            ("size", ((TracerouteMeasureCommand,), (0, 2048))),
+            ("packets", (
+                (
+                    PingMeasureCommand,
+                    TracerouteMeasureCommand,
+                    NtpMeasureCommand,
+                ), (1, 16))),
+            ("packet-interval", ((PingMeasureCommand,), (2, 30000))),
+            ("timeout", ((NtpMeasureCommand,), (1, 60000))),
+            ("destination-option-size", ((TracerouteMeasureCommand,), (0, 1024))),
+            ("hop-by-hop-option-size", ((TracerouteMeasureCommand,), (0, 2048))),
+            ("retry", ((DnsMeasureCommand,), (0, 10))),
+            ("udp-payload-size", ((DnsMeasureCommand,), (512, 4096))),
+        ]
+        for option, (klasses, extremes) in min_max_options:
             for klass in klasses:
-                for val in extremes:
+                lower = extremes[0] - 1
+                upper = extremes[1] + 1
+                for invalid in lower, upper:
                     with capture_sys_output() as (stdout, stderr):
-                        with self.assertRaises(SystemExit):
+                        try:
                             klass().init_args([
                                 klass.__name__.replace("MeasureCommand", "").lower(),
-                                "--{}".format(option), str(val)
+                                "--{}".format(option), str(invalid)
                             ])
+                        except SystemExit:
+                            pass
+                        else:
+                            self.fail("--{} for {} should fail for value {}".format(
+                                option, klass.__name__, invalid
+                            ))
                         self.assertEqual(
                             stderr.getvalue().split("\n")[-2],
                             "ripe-atlas measure: error: argument --{}: The "
                             "integer must be between {} and {}.".format(
-                                option, extremes[0] + 1, extremes[1] - 1
+                                option, extremes[0], extremes[1]
                             )
                         )
 


### PR DESCRIPTION
Synchronize option, limits and defaults with the API where relevant,and include a new dev script for checking the tools against the OpenAPI endpoint.

This means adding a few more options that are supported by the API but not the tools, and aligning the minimums and maximums with current reality. In general the behaviour of the CLI has not changed, except that server-side validation errors are less likely and certain values are now possible.