### PR TITLE
Update sagan to latest version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
         "python-dateutil",
         "requests>=2.7.0",
         "ripe.atlas.cousteau==1.4",
-        "ripe.atlas.sagan==1.2",
+        "ripe.atlas.sagan==1.2.2",
         "tzlocal",
         "pyyaml",
         "pyOpenSSL>=0.13",


### PR DESCRIPTION
Just noticed the [requirements](https://requires.io/github/RIPE-NCC/ripe-atlas-tools/requirements/?branch=master) badge and it points that sagan is a bit outdated. Latest version should be safe according to releases [changelog](https://github.com/RIPE-NCC/ripe.atlas.sagan/releases).