### PR TITLE
Add result date and time to traceroute, NTP and SSL renderers

### DIFF
--- a/ripe/atlas/tools/renderers/ntp.py
+++ b/ripe/atlas/tools/renderers/ntp.py
@@ -25,8 +25,7 @@ class Renderer(BaseRenderer):
 
     def on_result(self, result):
         created = result.created.astimezone(get_localzone())
-        probe_id = result.probe_id
-        r = self.get_formatted_response(probe_id, created, result)
+        r = self.get_formatted_response(result)
         if not r:
             r = colourise('No results\n', 'red')
         return "\n{}\n{}\n\n{}".format(
@@ -35,7 +34,8 @@ class Renderer(BaseRenderer):
             r
         )
 
-    def get_formatted_response(self, probe_id, created, result):
+    @staticmethod
+    def get_formatted_response(result):
         leap = result.leap_second_indicator
         stratum = result.stratum
         v = result.version

--- a/ripe/atlas/tools/renderers/ntp.py
+++ b/ripe/atlas/tools/renderers/ntp.py
@@ -21,16 +21,19 @@ from ..helpers.colours import colourise
 
 class Renderer(BaseRenderer):
     RENDERS = [BaseRenderer.TYPE_NTP]
+    TIME_FORMAT = "%a %b %d %H:%M:%S %Z %Y"
 
     def on_result(self, result):
         created = result.created.astimezone(get_localzone())
         probe_id = result.probe_id
-        r = '\n\nProbe #{0}\n{1}\n'.format(probe_id, '=' * 79)
-        res = self.get_formatted_response(probe_id, created, result)
-        if res:
-            return r + res
-        else:
-            return colourise(r + 'No results\n', 'red')
+        r = self.get_formatted_response(probe_id, created, result)
+        if not r:
+            r = colourise('No results\n', 'red')
+        return "\n{}\n{}\n\n{}".format(
+            colourise("Probe #{}".format(result.probe_id), "bold"),
+            colourise(created.strftime(self.TIME_FORMAT), "bold"),
+            r
+        )
 
     def get_formatted_response(self, probe_id, created, result):
         leap = result.leap_second_indicator

--- a/ripe/atlas/tools/renderers/sslcert.py
+++ b/ripe/atlas/tools/renderers/sslcert.py
@@ -13,8 +13,10 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from tzlocal import get_localzone
 import OpenSSL
 
+from ..helpers.colours import colourise
 from ..helpers.sanitisers import sanitise
 from .base import Renderer as BaseRenderer
 
@@ -22,12 +24,18 @@ from .base import Renderer as BaseRenderer
 class Renderer(BaseRenderer):
 
     RENDERS = [BaseRenderer.TYPE_SSLCERT]
+    TIME_FORMAT = "%a %b %d %H:%M:%S %Z %Y"
 
     def on_result(self, result):
         r = ""
         for certificate in result.certificates:
             r += self.get_formatted_response(certificate)
-        return "\nProbe #{0}\n{1}\n".format(result.probe_id, r)
+        created = result.created.astimezone(get_localzone())
+        return "\n{}\n{}\n{}\n".format(
+            colourise("Probe #{}".format(result.probe_id), "bold"),
+            colourise(created.strftime(self.TIME_FORMAT), "bold"),
+            r
+        )
 
     @classmethod
     def get_formatted_response(cls, certificate):

--- a/ripe/atlas/tools/renderers/traceroute.py
+++ b/ripe/atlas/tools/renderers/traceroute.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from tzlocal import get_localzone
 from .base import Renderer as BaseRenderer
 
 from ..helpers.colours import colourise
@@ -23,7 +24,7 @@ from ..ipdetails import IP
 class Renderer(BaseRenderer):
 
     RENDERS = [BaseRenderer.TYPE_TRACEROUTE]
-
+    TIME_FORMAT = "%a %b %d %H:%M:%S %Z %Y"
     DEFAULT_SHOW_ASNS = False
 
     @staticmethod
@@ -83,7 +84,9 @@ class Renderer(BaseRenderer):
                 rtts="  ".join(rtts)
             )
 
-        return "\n{}\n\n{}".format(
+        created = result.created.astimezone(get_localzone())
+        return "\n{}\n{}\n\n{}".format(
             colourise("Probe #{}".format(result.probe_id), "bold"),
+            colourise(created.strftime(self.TIME_FORMAT), "bold"),
             r
         )


### PR DESCRIPTION
When analyzing for example traceroute reports, it is crucial to know when was the result obtained.  This PR adds result date to the output of traceroute, SSL and NTP renderers.

I also simplified the NTP renderer, dropping unused variables/parameters.
All tests pass.