### PR TITLE
Go web option

### DIFF
--- a/docs/use.rst
+++ b/docs/use.rst
@@ -294,7 +294,7 @@ Options
 ==================  ==================  ========================================
 Option              Arguments           Explanation
 ==================  ==================  ========================================
-``--auth``          RIPE Atlas key      One of the RIPE Atlas key alias 
+``--auth``          RIPE Atlas key      One of the RIPE Atlas key alias
                     alias               configured for results fetching.
 
 ``--probes``        A comma-separated   Limit the report to only results
@@ -384,7 +384,7 @@ Options
 ==================  ==================  ========================================
 Option              Arguments           Explanation
 ==================  ==================  ========================================
-``--auth``          RIPE Atlas key      One of the RIPE Atlas key alias 
+``--auth``          RIPE Atlas key      One of the RIPE Atlas key alias
                     alias               configured for results fetching.
 
 ``--limit``         A number < 1000     The maximum number of results you want
@@ -479,9 +479,12 @@ Option                  Arguments           Explanation
                                             which you can later get information
                                             about the measurement.
 
-``--resolve-on-probe``                      Flag that indicates that a name 
-                                            should be resolved (using DNS) on 
-                                            the probe. Otherwise it will be 
+``--go-web``                                Don't wait for a response from the
+                                            measurement, just immediately open the measurement URL in the default web browser.
+
+``--resolve-on-probe``                      Flag that indicates that a name
+                                            should be resolved (using DNS) on
+                                            the probe. Otherwise it will be
                                             resolved on the RIPE Atlas servers.
 
 ``--interval``          An integer          Rather than run this measurement as

--- a/hackdub18.rst
+++ b/hackdub18.rst
@@ -30,3 +30,4 @@ Already existing stuff
 ======================
 - https://labs.ripe.net/Members/annika_wickert/using-ripe-atlas-to-monitor-game-service-connectivity
 - https://github.com/RIPE-Atlas-Community/ripe-atlas-community-contrib
+- https://github.com/emileaben/eyeballtrace                                                                                                - https://framagit.org/bortzmeyer/blaeu   

--- a/hackdub18.rst
+++ b/hackdub18.rst
@@ -1,0 +1,24 @@
+Dublin Hackathon 2018
+===================
+
+
+* Document how to use atlas tools in a hurry, NOC people in panic
+* Make the three step pocess into a 1 step - run now process
+* awlx has a use-case with country select probes in region in as
+
+
+
+Original Project idea and description
+===================================
+
+ Project_Name_1
+
+realtime ripe-atlas traceroute commandline: hack together a ripe-atlas commandline that is as smooth to use as possible.
+Currently in the commandline you need 3 steps, and in an 'the customer is screaming on the phone'-situation where traceroutes can narrow down a problem, you probably want
+to minimise the amount of thinking you need to do to maximise the result of measuring.
+ - a single command to do all steps (select right probes for your use case, do the measurement, print relevant results)
+ - make it as real-time as possible
+   - oversubscribe probes slightly for one-offs
+   - tweak measurement parameters for fast results (1 probing per hop, reduce timeout vals?)
+   - commandline results that are 'enriched' (show ASN, location, weirdnesses, nice short asn-names)
+   - steal good parts from https://github.com/emileaben/eyeballtrace ? / use/extend bleau? https://labs.ripe.net/Members/stephane_bortzmeyer/creating-ripe-atlas-one-off-measurements-with-blaeu

--- a/hackdub18.rst
+++ b/hackdub18.rst
@@ -10,6 +10,24 @@ API key, beginning:
 11febf03-5190-47e5-882a-.........
 
 
+Get started
+===========
+
+Install Python Pip, then:
+
+git clone https://github.com/kramse/ripe-atlas-tools/
+cd ripe-atlas-tools
+
+pip install pipenv
+pipenv --python 3
+pipenv install -e .
+
+
+When this is done, you can do
+pipenv shell
+
+That activates the environment, and is the command to use when doing work on this project.
+
 Original Project idea and description
 ===================================
 
@@ -30,4 +48,4 @@ Already existing stuff
 ======================
 - https://labs.ripe.net/Members/annika_wickert/using-ripe-atlas-to-monitor-game-service-connectivity
 - https://github.com/RIPE-Atlas-Community/ripe-atlas-community-contrib
-- https://github.com/emileaben/eyeballtrace                                                                                                - https://framagit.org/bortzmeyer/blaeu   
+- https://github.com/emileaben/eyeballtrace                                                                                                - https://framagit.org/bortzmeyer/blaeu

--- a/hackdub18.rst
+++ b/hackdub18.rst
@@ -6,6 +6,8 @@ Dublin Hackathon 2018
 * Make the three step pocess into a 1 step - run now process
 * awlx has a use-case with country select probes in region in as
 
+API key, beginning:
+11febf03-5190-47e5-882a-.........
 
 
 Original Project idea and description

--- a/ripe/atlas/tools/commands/measure/base.py
+++ b/ripe/atlas/tools/commands/measure/base.py
@@ -16,6 +16,7 @@
 from __future__ import print_function, absolute_import
 
 import re
+import webbrowser
 
 from collections import OrderedDict
 
@@ -122,6 +123,11 @@ class Command(BaseCommand):
             help="Don't wait for a response from the measurement, just return "
                  "the URL at which you can later get information about the "
                  "measurement."
+        )
+        self.parser.add_argument(
+            "--go-web",
+            action="store_true",
+            help="Open the measurement in a webbrowser immediately."
         )
         self.parser.add_argument(
             "--set-alias",
@@ -256,6 +262,16 @@ class Command(BaseCommand):
             "Looking good!  Your measurement was created and details about "
             "it can be found here:\n\n  {0}".format(url)
         )
+        if self.arguments.go_web:
+            self.ok(
+                "Opening the url in the browser\n\n "
+            )
+            if not webbrowser.open(url):
+                self.ok(
+                    "It looks like your system doesn't have a web browser "
+                    "available.  You'll have to go there manually: {0}".format(url)
+                    )
+
 
         if self.arguments.set_alias:
             alias = self.arguments.set_alias


### PR DESCRIPTION
Hi 

I thought it would be nice to have an option to open browser immediately when doing measurements.
I know there is a go option, but then you need to know the id, which is created when you do the measurement.

how to use:
ripe-atlas measure traceroute --target www.nordu.net --go-web
