### PR TITLE
Adding option to open measurement URL in browser

### DIFF
--- a/docs/use.rst
+++ b/docs/use.rst
@@ -294,7 +294,7 @@ Options
 ==================  ==================  ========================================
 Option              Arguments           Explanation
 ==================  ==================  ========================================
-``--auth``          RIPE Atlas key      One of the RIPE Atlas key alias 
+``--auth``          RIPE Atlas key      One of the RIPE Atlas key alias
                     alias               configured for results fetching.
 
 ``--probes``        A comma-separated   Limit the report to only results
@@ -384,7 +384,7 @@ Options
 ==================  ==================  ========================================
 Option              Arguments           Explanation
 ==================  ==================  ========================================
-``--auth``          RIPE Atlas key      One of the RIPE Atlas key alias 
+``--auth``          RIPE Atlas key      One of the RIPE Atlas key alias
                     alias               configured for results fetching.
 
 ``--limit``         A number < 1000     The maximum number of results you want
@@ -479,9 +479,12 @@ Option                  Arguments           Explanation
                                             which you can later get information
                                             about the measurement.
 
-``--resolve-on-probe``                      Flag that indicates that a name 
-                                            should be resolved (using DNS) on 
-                                            the probe. Otherwise it will be 
+``--go-web``                                Don't wait for a response from the
+                                            measurement, just immediately open the measurement URL in the default web browser.
+
+``--resolve-on-probe``                      Flag that indicates that a name
+                                            should be resolved (using DNS) on
+                                            the probe. Otherwise it will be
                                             resolved on the RIPE Atlas servers.
 
 ``--interval``          An integer          Rather than run this measurement as

--- a/ripe/atlas/tools/commands/measure/base.py
+++ b/ripe/atlas/tools/commands/measure/base.py
@@ -16,6 +16,7 @@
 from __future__ import print_function, absolute_import
 
 import re
+import webbrowser
 
 from collections import OrderedDict
 
@@ -122,6 +123,11 @@ class Command(BaseCommand):
             help="Don't wait for a response from the measurement, just return "
                  "the URL at which you can later get information about the "
                  "measurement."
+        )
+        self.parser.add_argument(
+            "--go-web",
+            action="store_true",
+            help="Open the measurement in a webbrowser immediately."
         )
         self.parser.add_argument(
             "--set-alias",
@@ -256,6 +262,16 @@ class Command(BaseCommand):
             "Looking good!  Your measurement was created and details about "
             "it can be found here:\n\n  {0}".format(url)
         )
+        if self.arguments.go_web:
+            self.ok(
+                "Opening the url in the browser\n\n "
+            )
+            if not webbrowser.open(url):
+                self.ok(
+                    "It looks like your system doesn't have a web browser "
+                    "available.  You'll have to go there manually: {0}".format(url)
+                    )
+
 
         if self.arguments.set_alias:
             alias = self.arguments.set_alias

--- a/ripe/atlas/tools/commands/measure/base.py
+++ b/ripe/atlas/tools/commands/measure/base.py
@@ -272,7 +272,6 @@ class Command(BaseCommand):
                     "available.  You'll have to go there manually: {0}".format(url)
                     )
 
-
         if self.arguments.set_alias:
             alias = self.arguments.set_alias
             aliases["measurement"][alias] = pk


### PR DESCRIPTION
Hi

I thought it would be nice to have an option to open browser immediately when doing measurements.
I know there is a go option, but then you need to know the id, which is created when you do the measurement.

how to use:
ripe-atlas measure traceroute --target www.nordu.net --go-web
