### PR TITLE
Trying to make the initial experience better, if 403 errors

### DIFF
--- a/ripe/atlas/tools/commands/measure/base.py
+++ b/ripe/atlas/tools/commands/measure/base.py
@@ -455,13 +455,14 @@ class Command(BaseCommand):
 
         if response["error"]["status"] == 403:
             message = (
-            "There was a problem communicating with the RIPE Atlas "
-            "infrastructure. \nStatus is 403 so you probably need an API key. "
-            "Register and create API Keys at https://atlas.ripe.net/\n"
-            "Create the new key with the permission Create a new user "
-            "defined measurement and install using:\n\n"
-            "   ripe-atlas configure --set authorisation.create=MY_API_KEY\n\n"
-            "The message given was:\n\n  {}"
+                "There was a problem communicating with the RIPE Atlas "
+                "infrastructure. \nStatus is 403 so you probably need an API "
+                "key. Register and create API Keys at "
+                "https://atlas.ripe.net/\n"
+                "Create the new key with the permission Create a new user "
+                "defined measurement and install using:\n\n"
+                "   ripe-atlas configure --set authorisation.create=MY_API_KEY\n\n"
+                "The message given was:\n\n  {}"
             ).format(error_detail)
 
         raise RipeAtlasToolsException(message)

--- a/ripe/atlas/tools/commands/measure/base.py
+++ b/ripe/atlas/tools/commands/measure/base.py
@@ -453,4 +453,15 @@ class Command(BaseCommand):
             "infrastructure.  The message given was:\n\n  {}"
         ).format(error_detail)
 
+        if response["error"]["status"] == 403:
+            message = (
+            "There was a problem communicating with the RIPE Atlas "
+            "infrastructure. \nStatus is 403 so you probably need an API key. "
+            "Register and create API Keys at https://atlas.ripe.net/\n"
+            "Create the new key with the permission Create a new user "
+            "defined measurement and install using:\n\n"
+            "   ripe-atlas configure --set authorisation.create=MY_API_KEY\n\n"
+            "The message given was:\n\n  {}"
+            ).format(error_detail)
+
         raise RipeAtlasToolsException(message)


### PR DESCRIPTION
Working in the RIPE NCC Hackathon in Dublin we are trying to make the initial experience using the tools better. One thing is that a lot of people will be missing an API key so they will get the 403 status code. So this is just a small helping text guiding the user a bit. 