### PR TITLE
Proper XDG Base Directory Specification support.

### DIFF
--- a/ripe/atlas/tools/cache.py
+++ b/ripe/atlas/tools/cache.py
@@ -28,6 +28,7 @@ try:
 except ImportError:
     import dbm  # ... and on Python3 dbm does the same
 
+from .helpers import xdg
 
 class LocalCache(object):
     """
@@ -110,8 +111,7 @@ class LocalCache(object):
 
         db_path = os.path.join("/", "tmp", file_name)
         if "HOME" in os.environ:
-            db_path = os.path.join(
-                os.environ["HOME"], ".config", "ripe-atlas-tools", file_name)
+            db_path = os.path.join(xdg.get_config_home(),, file_name)
 
         try:
             os.makedirs(os.path.dirname(db_path))

--- a/ripe/atlas/tools/commands/base.py
+++ b/ripe/atlas/tools/commands/base.py
@@ -22,6 +22,7 @@ import re
 import six
 import sys
 
+from ..helpers import xdg
 from ..helpers.colours import colourise
 from ..version import __version__
 
@@ -81,10 +82,7 @@ class Command(object):
 
     @classmethod
     def _get_user_command_path(cls):
-        user_base_path = os.path.join(
-            os.path.expanduser("~"), ".config", "ripe-atlas-tools",
-        )
-        return os.path.join(user_base_path, "commands")
+        return os.path.join(xdg.get_config_home(), "commands")
 
     @classmethod
     def _load_commands(cls):

--- a/ripe/atlas/tools/helpers/xdg.py
+++ b/ripe/atlas/tools/helpers/xdg.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2016 RIPE NCC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import os.path
+
+def get_config_home():
+    """
+    """
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    if config_home is None:
+        config_home = os.path.expanduser("~/.config")
+    return os.path.join(config_home, "ripe-atlas-tools")

--- a/ripe/atlas/tools/renderers/base.py
+++ b/ripe/atlas/tools/renderers/base.py
@@ -19,6 +19,7 @@ import pkgutil
 import sys
 
 from ..exceptions import RipeAtlasToolsException
+from ..helpers import xdg
 
 
 class Renderer(object):
@@ -51,8 +52,7 @@ class Renderer(object):
 
         paths = [os.path.dirname(__file__)]
         if "HOME" in os.environ:
-            path = os.path.join(
-                os.environ["HOME"], ".config", "ripe-atlas-tools")
+            path = xdg.get_config_home()
             sys.path.append(path)
             paths += [os.path.join(path, "renderers")]
 

--- a/ripe/atlas/tools/settings/__init__.py
+++ b/ripe/atlas/tools/settings/__init__.py
@@ -19,11 +19,11 @@ import os
 import re
 import yaml
 
+from ..helpers import xdg
 
 class UserSettingsParser(object):
 
-    USER_CONFIG_DIR = os.path.join(
-        os.path.expanduser("~"), ".config", "ripe-atlas-tools")
+    USER_CONFIG_DIR = xdg.get_config_home()
 
     USER_RC = None
 


### PR DESCRIPTION
`ripe-atlas` currently half-implements the XDG Base Directory Specification. This commit fixes the support to look for `XDG_CONFIG_HOME` first, as it ought to.