### PR TITLE
Remove the py prefix from OpenBSD PKGNAME

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -162,7 +162,7 @@ easy:
 
 .. code:: bash
 
-    sudo pkg_add py-ripe.atlas.tools
+    sudo pkg_add ripe.atlas.tools
 
 
 .. _installation-from-freebsd:


### PR DESCRIPTION
The OpenBSD package name of ripe-atlas-tools changed from py-ripe.atlas.tools to ripe.atlas.tools from OpenBSD 6.1
http://cvsweb.openbsd.org/cgi-bin/cvsweb/ports/net/py-ripe.atlas.tools/pkg/PLIST

I confirmed the instruction using "pkg_add ripe.atlas.tools" at OpenBSD 6.4
