### PR TITLE
Add --tls option to schedule DNS requests over TLS

### DIFF
--- a/ripe/atlas/tools/commands/measure/dns.py
+++ b/ripe/atlas/tools/commands/measure/dns.py
@@ -113,6 +113,12 @@ class DnsMeasureCommand(Command):
             type=ArgumentType.integer_range(minimum=100, maximum=30000),
             help="Per packet timeout in milliseconds",
         )
+        specific.add_argument(
+            "--tls",
+            action="store_true",
+            default=conf["specification"]["types"]["dns"]["tls"],
+            help="Send query using DNS-over-TLS"
+        )
 
     def clean_target(self):
         """
@@ -145,6 +151,7 @@ class DnsMeasureCommand(Command):
         r["retry"] = self.arguments.retry
         r["udp_payload_size"] = self.arguments.udp_payload_size
         r["use_probe_resolver"] = "target" not in r
+	r["tls"] = self.arguments.tls
         if self.arguments.timeout is not None:
             r["timeout"] = self.arguments.timeout
 

--- a/ripe/atlas/tools/settings/__init__.py
+++ b/ripe/atlas/tools/settings/__init__.py
@@ -127,6 +127,7 @@ class Configuration(UserSettingsParser):
                     "set-rd-bit": True,
                     "retry": 0,
                     "timeout": None,
+		    "tls": False,
                 },
                 "http": {
                     "header-bytes": 0,


### PR DESCRIPTION
This is a contribution from the Shadow Hunters hackathon team during the AIS2019
In the course of our hackathon challenge we scheduled DNS over TLS measurements from probes in Africa to cloud resolvers to compare their RTT and responsiveness to local resolvers.
To our surprise we even found 14 local DNS-over-TLS configured on probes in Africa.