### PR TITLE
Proper XDG Base Directory Specification support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ language: python
 sudo: false
 env:
   - TOXENV=py27
-  - TOXENV=py34
   - TOXENV=py27-pyflakes
   - TOXENV=py27-pep8
   - TOXENV=py27-coverage
+  - TOXENV=py35
+  - TOXENV=py35-syntax
 install:
   - pip install tox
   - pip install coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,9 @@
 language: python
+python:
+  - "2.7"
+  - "3.5"
+  - "3.7"
 sudo: false
-env:
-  - TOXENV=py27
-  - TOXENV=py27-pyflakes
-  - TOXENV=py27-pep8
-  - TOXENV=py27-coverage
-  - TOXENV=py35
-  - TOXENV=py35-syntax
 install:
   - pip install tox
   - pip install coveralls

--- a/ripe/atlas/tools/cache.py
+++ b/ripe/atlas/tools/cache.py
@@ -28,6 +28,8 @@ try:
 except ImportError:
     import dbm  # ... and on Python3 dbm does the same
 
+from .helpers import xdg
+
 
 class LocalCache(object):
     """
@@ -110,8 +112,7 @@ class LocalCache(object):
 
         db_path = os.path.join("/", "tmp", file_name)
         if "HOME" in os.environ:
-            db_path = os.path.join(
-                os.environ["HOME"], ".config", "ripe-atlas-tools", file_name)
+            db_path = os.path.join(xdg.get_config_home(), file_name)
 
         try:
             os.makedirs(os.path.dirname(db_path))

--- a/ripe/atlas/tools/commands/base.py
+++ b/ripe/atlas/tools/commands/base.py
@@ -22,6 +22,7 @@ import re
 import six
 import sys
 
+from ..helpers import xdg
 from ..helpers.colours import colourise
 from ..version import __version__
 
@@ -81,10 +82,7 @@ class Command(object):
 
     @classmethod
     def _get_user_command_path(cls):
-        user_base_path = os.path.join(
-            os.path.expanduser("~"), ".config", "ripe-atlas-tools",
-        )
-        return os.path.join(user_base_path, "commands")
+        return os.path.join(xdg.get_config_home(), "commands")
 
     @classmethod
     def _load_commands(cls):

--- a/ripe/atlas/tools/commands/base.py
+++ b/ripe/atlas/tools/commands/base.py
@@ -304,10 +304,7 @@ class MetaDataMixin(object):
 
     @staticmethod
     def _render_line(header, value):
-        # Make sure we don't mix unicode and strings
-        if six.PY2 and isinstance(value, six.string_types):
-            value = unicode(value)
-
+        value = six.text_type(value)
         log = u"{}  {}".format(colourise("{:25}".format(header), "bold"), value).encode("utf-8")
         print(log)
 

--- a/ripe/atlas/tools/helpers/colours.py
+++ b/ripe/atlas/tools/helpers/colours.py
@@ -38,9 +38,7 @@ class Colour(object):
 
     @classmethod
     def _colourise(cls, text, colour):
-        # Make sure we don't mix unicode and strings
-        if six.PY2 and isinstance(text, six.string_types):
-            text = unicode(text)
+        text = six.text_type(text)
 
         return u"{}[{}m{}{}[0m".format(chr(0x1b), colour, text, chr(0x1b))
 

--- a/ripe/atlas/tools/helpers/sanitisers.py
+++ b/ripe/atlas/tools/helpers/sanitisers.py
@@ -26,8 +26,7 @@ def sanitise(s, strip_newlines=True):
     if not isinstance(s, six.string_types):
         return s
 
-    if six.PY2:
-        s = unicode(s)
+    s = six.text_type(s)
 
     if not strip_newlines:
         return s.translate(

--- a/ripe/atlas/tools/helpers/xdg.py
+++ b/ripe/atlas/tools/helpers/xdg.py
@@ -1,0 +1,26 @@
+# Copyright (c) 2016 RIPE NCC
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import os.path
+
+
+def get_config_home():
+    """
+    """
+    config_home = os.environ.get("XDG_CONFIG_HOME")
+    if config_home is None:
+        config_home = os.path.expanduser("~/.config")
+    return os.path.join(config_home, "ripe-atlas-tools")

--- a/ripe/atlas/tools/renderers/base.py
+++ b/ripe/atlas/tools/renderers/base.py
@@ -19,6 +19,7 @@ import pkgutil
 import sys
 
 from ..exceptions import RipeAtlasToolsException
+from ..helpers import xdg
 
 
 class Renderer(object):
@@ -51,8 +52,7 @@ class Renderer(object):
 
         paths = [os.path.dirname(__file__)]
         if "HOME" in os.environ:
-            path = os.path.join(
-                os.environ["HOME"], ".config", "ripe-atlas-tools")
+            path = xdg.get_config_home()
             sys.path.append(path)
             paths += [os.path.join(path, "renderers")]
 

--- a/ripe/atlas/tools/settings/__init__.py
+++ b/ripe/atlas/tools/settings/__init__.py
@@ -19,11 +19,12 @@ import os
 import re
 import yaml
 
+from ..helpers import xdg
+
 
 class UserSettingsParser(object):
 
-    USER_CONFIG_DIR = os.path.join(
-        os.path.expanduser("~"), ".config", "ripe-atlas-tools")
+    USER_CONFIG_DIR = xdg.get_config_home()
 
     USER_RC = None
 

--- a/setup.py
+++ b/setup.py
@@ -43,6 +43,7 @@ setup(
     tests_require=[
         "nose",
         "coverage",
+        "mock==3.0.5",
     ],
     extras_require={
         "doc": ["sphinx", "sphinx_rtd_theme"],

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,6 @@ setup(
     tests_require=[
         "nose",
         "coverage",
-        "mock",
     ],
     extras_require={
         "doc": ["sphinx", "sphinx_rtd_theme"],

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,13 @@
 [tox]
-envlist=py27-pyflakes, py27-pep8, py27-coverage, py27, py34, py34-syntax, py37, py37-syntax
+envlist=py27-pyflakes, py27-pep8, py27-coverage, py27, py35, py35-syntax, py37, py37-syntax
 
 [testenv]
 commands=python setup.py test []
 deps=nose
+
+[testenv:py27]
+basepython=python2.7
+deps=mock==3.0.5
 
 [testenv:py27-pep8]
 commands=pep8 ripe --max-line-length=100
@@ -21,11 +25,15 @@ commands=
      coverage run --source=ripe setup.py test
      coverage report -m
 deps=coverage
+     mock==3.0.5
 
-[testenv:py34-syntax]
+[testenv:py35]
+basepython=python3.5
+
+[testenv:py35-syntax]
 whitelist_externals=bash
 commands=bash -c "find ripe/ tests/ -name '*.py' | xargs python -m py_compile"
-basepython=python3.4
+basepython=python3.5
 deps=
 
 [testenv:py37-syntax]

--- a/tox.ini
+++ b/tox.ini
@@ -1,43 +1,20 @@
 [tox]
-envlist=py27-pyflakes, py27-pep8, py27-coverage, py27, py35, py35-syntax, py37, py37-syntax
+envlist=py, py-pyflakes, py-pep8, py-coverage
 
-[testenv]
+[testenv:py]
 commands=python setup.py test []
 deps=nose
 
-[testenv:py27]
-basepython=python2.7
-deps=mock==3.0.5
-
-[testenv:py27-pep8]
+[testenv:py-pep8]
 commands=pep8 ripe --max-line-length=100
-basepython=python2.7
 deps=pep8
 
-[testenv:py27-pyflakes]
+[testenv:py-pyflakes]
 commands=pyflakes ripe
-basepython=python2.7
 deps=pyflakes
 
-[testenv:py27-coverage]
-basepython=python2.7
+[testenv:py-coverage]
 commands=
      coverage run --source=ripe setup.py test
      coverage report -m
 deps=coverage
-     mock==3.0.5
-
-[testenv:py35]
-basepython=python3.5
-
-[testenv:py35-syntax]
-whitelist_externals=bash
-commands=bash -c "find ripe/ tests/ -name '*.py' | xargs python -m py_compile"
-basepython=python3.5
-deps=
-
-[testenv:py37-syntax]
-whitelist_externals=bash
-commands=bash -c "find ripe/ tests/ -name '*.py' | xargs python -m py_compile"
-basepython=python3.7
-deps=


### PR DESCRIPTION
`ripe-atlas` currently half-implements the XDG Base Directory Specification. This commit fixes the support to look for `XDG_CONFIG_HOME` first, as it ought to.

(This PR fixes #204, which had a typo, and thus was broken.)

Unfortunately, this PR also contains a bunch of changes to make the build system happy as the test suite has been broken for quite a while.

I should note that I also had to peg the version of mock at 3.0.5 as this is the last version that supports Python 2.7.