### PR TITLE
SSL consistency renderer cannot call max() with no arguments

### DIFF
--- a/ripe/atlas/tools/renderers/ssl_consistency.py
+++ b/ripe/atlas/tools/renderers/ssl_consistency.py
@@ -64,6 +64,8 @@ class Renderer(BaseRenderer):
         Gets the number of probes that have seen the most popular
         (in terms of probes) cert.
         """
+        if not self.uniqcerts:
+            return 0
         return max(
             [self.uniqcerts[cert_id]["cnt"] for cert_id in self.uniqcerts]
         )

--- a/tests/renderers/ssl_consistency.py
+++ b/tests/renderers/ssl_consistency.py
@@ -189,6 +189,18 @@ class TestSSLConsistency(unittest.TestCase):
             renderer.gather_unique_certs(sagans)
             self.assertEquals(renderer.get_nprobes_ofpopular_cert(), 11)
 
+    def test_get_nprobes_ofpopular_cert_empty(self):
+        """Tests that getting the number of probes for popular certs does not
+        throw an error when there are no valid certificates."""
+
+        path = 'ripe.atlas.tools.helpers.rendering.Probe.get_many'
+        with mock.patch(path) as mock_get_many:
+            mock_get_many.return_value = self.probes.values()
+            sagans = SaganSet([])
+            renderer = Renderer()
+            renderer.gather_unique_certs(sagans)
+            self.assertEquals(renderer.get_nprobes_ofpopular_cert(), 0)
+
     def test_render_certificate(self):
         """Tests rendering of single certificate."""
         expected_output = (


### PR DESCRIPTION
When a mesurement has no cert data because all of the probes failed, an exception
is thrown in the ssl consistency renderer. This max() call needs to be guarded with
a check.

```
Traceback (most recent call last):
  File "/Users/tomarnfeld/src/github.com/ripe-ncc/ripe-atlas-tools.git/tests/renderers/ssl_consistency.py", line 202, in test_get_nprobes_ofpopular_cert_empty
    self.assertEquals(renderer.get_nprobes_ofpopular_cert(), 0)
  File "/Users/tomarnfeld/src/github.com/ripe-ncc/ripe-atlas-tools.git/ripe/atlas/tools/renderers/ssl_consistency.py", line 68, in get_nprobes_ofpopular_cert
    [self.uniqcerts[cert_id]["cnt"] for cert_id in self.uniqcerts]
ValueError: max() arg is an empty sequence
```

I replicated this by running a simple probe measurement, for example.

```
$ ripe-atlas measure sslcert --target 9.8.7.6 --probes 1
...
```

Rendering the measurement once it has failed to probe generates this exception.

```
$ ripe-atlas report 26487063 --renderer ssl_consistency

WARNING:root:connect: timeout
Traceback (most recent call last):
  File "/Users/tomarnfeld/src/notebooks/env/bin/ripe-atlas", line 151, in <module>
    sys.exit(RipeAtlas().main())
  File "/Users/tomarnfeld/src/notebooks/env/bin/ripe-atlas", line 146, in main
    cmd.run()
  File "/Users/tomarnfeld/src/notebooks/env/lib/python3.7/site-packages/ripe/atlas/tools/commands/report.py", line 205, in run
    Rendering(renderer=renderer, payload=results).render()
  File "/Users/tomarnfeld/src/notebooks/env/lib/python3.7/site-packages/ripe/atlas/tools/helpers/rendering.py", line 102, in render
    print(self.renderer.additional(self.payload), end="")
  File "/Users/tomarnfeld/src/notebooks/env/lib/python3.7/site-packages/ripe/atlas/tools/renderers/ssl_consistency.py", line 33, in additional
    most_seen_cert = self.get_nprobes_ofpopular_cert()
  File "/Users/tomarnfeld/src/notebooks/env/lib/python3.7/site-packages/ripe/atlas/tools/renderers/ssl_consistency.py", line 68, in get_nprobes_ofpopular_cert
    [self.uniqcerts[cert_id]["cnt"] for cert_id in self.uniqcerts]
ValueError: max() arg is an empty sequence
```