### PR TITLE
Add possibility to pass API keys using env variables

### DIFF
--- a/ripe/atlas/tools/commands/measure/base.py
+++ b/ripe/atlas/tools/commands/measure/base.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import re
 import webbrowser
 
@@ -93,8 +94,9 @@ class Command(BaseCommand):
         self.parser.add_argument(
             "--auth",
             type=str,
-            default=conf["authorisation"]["create"],
+            default=os.getenv("ATLAS_CREATE_KEY", conf["authorisation"]["create"]),
             help="The API key you want to use to create the measurement"
+                 " (can be as well passed using ATLAS_CREATE_KEY environment variable)"
         )
         self.parser.add_argument(
             "--af",

--- a/ripe/atlas/tools/commands/report.py
+++ b/ripe/atlas/tools/commands/report.py
@@ -13,6 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import os
 import sys
 try:
     import ujson as json
@@ -80,6 +81,7 @@ class Command(BaseCommand):
                  "To configure an API key alias, use "
                  "ripe-atlas configure --set authorisation.fetch_aliases."
                  "ALIAS_NAME=YOUR_KEY"
+                 " (can be as well passed using ATLAS_FETCH_KEY environment variable)"
         )
         self.parser.add_argument(
             "--probes",
@@ -134,6 +136,8 @@ class Command(BaseCommand):
         Renderer.add_arguments_for_available_renderers(self.parser)
 
     def _get_request_auth(self):
+        if os.getenv("ATLAS_FETCH_KEY"):
+            return os.getenv("ATLAS_FETCH_KEY")
         if self.arguments.auth:
             return conf["authorisation"]["fetch_aliases"][self.arguments.auth]
         else:


### PR DESCRIPTION
This pull request adds possibility to pass create and fetch API keys with `ATLAS_CREATE_KEY` and `ATLAS_FETCH_KEY` environment variables.