### PR TITLE
Fix --location probe search

### DIFF
--- a/ripe/atlas/tools/settings/__init__.py
+++ b/ripe/atlas/tools/settings/__init__.py
@@ -69,6 +69,7 @@ class Configuration(UserSettingsParser):
             "fetch": "",
             "fetch_aliases": {},
             "create": "",
+            "google_geocoding": "",
         },
         "specification": {
             "af": 4,


### PR DESCRIPTION
Google has changed the Geocoding API conditions, now every request has
to be authenticated with an API key of an account connected to a billing
account. Thus I added an option to provide such API key on command line
as well as in the config file.

I also fixed the error reporting so any Google API errors are presented
to the user.

Signed-off-by: Ondřej Caletka <ondrej@caletka.cz>