### PR TITLE
Correct error in size of field ID in probe_search.py 

### DIFF
--- a/ripe/atlas/tools/commands/probe_search.py
+++ b/ripe/atlas/tools/commands/probe_search.py
@@ -38,7 +38,7 @@ class Command(BaseCommand):
     )
 
     COLUMNS: Dict[str, tabular.ColumnDef] = {
-        "id": {"align": ">", "width": 5},
+        "id": {"align": ">", "width": 7},
         "asn_v4": {"align": ">", "width": 6},
         "asn_v6": {"align": ">", "width": 6},
         "country": {"align": "^", "width": 7},


### PR DESCRIPTION
Increasing of characters width for the field "ID". It was fixed to 5, but currently the ID of the probes is up to 7 ciphers (characters).